### PR TITLE
[#14] ポジション・保有銘柄ステート管理

### DIFF
--- a/src/quantmind/portfolio/__init__.py
+++ b/src/quantmind/portfolio/__init__.py
@@ -1,0 +1,19 @@
+"""ポジション・保有銘柄ステート管理."""
+
+from quantmind.portfolio.state import (
+    MAX_POSITIONS,
+    Position,
+    close_position,
+    list_open,
+    open_position,
+    portfolio_summary,
+)
+
+__all__ = [
+    "MAX_POSITIONS",
+    "Position",
+    "close_position",
+    "list_open",
+    "open_position",
+    "portfolio_summary",
+]

--- a/src/quantmind/portfolio/__main__.py
+++ b/src/quantmind/portfolio/__main__.py
@@ -1,0 +1,73 @@
+"""ポジション CLI: open / close / list."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from quantmind.portfolio.state import (
+    close_position,
+    list_closed,
+    list_open,
+    open_position,
+    portfolio_summary,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.portfolio")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    op = sub.add_parser("open", help="新規エントリー")
+    op.add_argument("code")
+    op.add_argument("qty", type=int)
+    op.add_argument("price", type=float)
+    op.add_argument("--target", type=float)
+    op.add_argument("--stop", type=float)
+    op.add_argument("--scenario", help="反証シナリオID")
+    op.add_argument("--date", help="エントリー日 YYYY-MM-DD")
+
+    cl = sub.add_parser("close", help="クローズ")
+    cl.add_argument("position_id")
+    cl.add_argument("price", type=float)
+    cl.add_argument("--date", help="クローズ日 YYYY-MM-DD")
+
+    sub.add_parser("list", help="現在保有を一覧")
+    sub.add_parser("history", help="クローズ済みを一覧")
+    sub.add_parser("summary", help="評価サマリ")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "open":
+        pos = open_position(
+            args.code,
+            args.qty,
+            args.price,
+            entry_date=date.fromisoformat(args.date) if args.date else None,
+            target_price=args.target,
+            stop_price=args.stop,
+            scenario_id=args.scenario,
+        )
+        print(f"opened {pos.id}: {pos.code} x{pos.qty} @ {pos.entry_price}")
+    elif args.cmd == "close":
+        pos = close_position(
+            args.position_id,
+            args.price,
+            exit_date=date.fromisoformat(args.date) if args.date else None,
+        )
+        print(f"closed {pos.id}: pnl={pos.realized_pnl}")
+    elif args.cmd == "list":
+        for p in list_open():
+            print(f"{p.id} {p.code} qty={p.qty} entry={p.entry_price} target={p.target_price} stop={p.stop_price}")
+    elif args.cmd == "history":
+        for p in list_closed():
+            print(f"{p.id} {p.code} entry={p.entry_price} exit={p.exit_price} pnl={p.realized_pnl}")
+    elif args.cmd == "summary":
+        s = portfolio_summary()
+        for k, v in s.items():
+            print(f"{k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/portfolio/state.py
+++ b/src/quantmind/portfolio/state.py
@@ -1,0 +1,150 @@
+"""保有銘柄ステート管理 (positions テーブル CRUD)."""
+
+from __future__ import annotations
+
+import uuid
+import warnings
+from dataclasses import dataclass
+from datetime import date
+
+from quantmind.storage import get_conn
+
+MAX_POSITIONS = 5
+
+
+@dataclass(frozen=True)
+class Position:
+    id: str
+    code: str
+    qty: int
+    entry_price: float
+    entry_date: date
+    target_price: float | None
+    stop_price: float | None
+    scenario_id: str | None
+    status: str
+    exit_price: float | None
+    exit_date: date | None
+    realized_pnl: float | None
+
+
+def _row_to_position(row: tuple) -> Position:
+    return Position(
+        id=row[0],
+        code=row[1],
+        qty=row[2],
+        entry_price=row[3],
+        entry_date=row[4],
+        target_price=row[5],
+        stop_price=row[6],
+        scenario_id=row[7],
+        status=row[8],
+        exit_price=row[9],
+        exit_date=row[10],
+        realized_pnl=row[11],
+    )
+
+
+_SELECT = (
+    "SELECT id, code, qty, entry_price, entry_date, target_price, stop_price, "
+    "scenario_id, status, exit_price, exit_date, realized_pnl FROM positions"
+)
+
+
+def open_position(
+    code: str,
+    qty: int,
+    entry_price: float,
+    *,
+    entry_date: date | None = None,
+    target_price: float | None = None,
+    stop_price: float | None = None,
+    scenario_id: str | None = None,
+    notes: str | None = None,
+    position_id: str | None = None,
+) -> Position:
+    """新規エントリーを記録."""
+    pid = position_id or str(uuid.uuid4())
+    edate = entry_date or date.today()
+
+    open_codes = [p.code for p in list_open()]
+    if code in open_codes:
+        warnings.warn(f"{code}: 既に保有中のため新規追加扱い (累積管理は未対応)", stacklevel=2)
+    if len(open_codes) >= MAX_POSITIONS:
+        warnings.warn(
+            f"最大同時保有数 {MAX_POSITIONS} に達しています（現在 {len(open_codes)}）",
+            stacklevel=2,
+        )
+
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO positions(id, code, qty, entry_price, entry_date, target_price, stop_price, "
+            "scenario_id, status, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', ?)",
+            [pid, code, qty, entry_price, edate, target_price, stop_price, scenario_id, notes],
+        )
+        row = conn.execute(_SELECT + " WHERE id=?", [pid]).fetchone()
+    assert row is not None
+    return _row_to_position(row)
+
+
+def close_position(
+    position_id: str,
+    exit_price: float,
+    *,
+    exit_date: date | None = None,
+) -> Position:
+    """保有ポジションをクローズして実現損益を計算."""
+    xdate = exit_date or date.today()
+    with get_conn() as conn:
+        cur = conn.execute(_SELECT + " WHERE id=?", [position_id]).fetchone()
+        if cur is None:
+            raise ValueError(f"position not found: {position_id}")
+        pos = _row_to_position(cur)
+        if pos.status != "open":
+            raise ValueError(f"position {position_id} is already {pos.status}")
+        pnl = (exit_price - pos.entry_price) * pos.qty
+        conn.execute(
+            "UPDATE positions SET status='closed', exit_price=?, exit_date=?, realized_pnl=? WHERE id=?",
+            [exit_price, xdate, pnl, position_id],
+        )
+        row = conn.execute(_SELECT + " WHERE id=?", [position_id]).fetchone()
+    assert row is not None
+    return _row_to_position(row)
+
+
+def list_open() -> list[Position]:
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(_SELECT + " WHERE status='open' ORDER BY entry_date").fetchall()
+    return [_row_to_position(r) for r in rows]
+
+
+def list_closed() -> list[Position]:
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(_SELECT + " WHERE status='closed' ORDER BY exit_date").fetchall()
+    return [_row_to_position(r) for r in rows]
+
+
+def portfolio_summary(price_lookup: dict[str, float] | None = None) -> dict[str, float]:
+    """評価損益サマリを返す.
+
+    Parameters
+    ----------
+    price_lookup : dict[str, float] | None
+        ``code → 現在値`` のマップ。指定された銘柄のみ評価損益を加算。
+    """
+    open_pos = list_open()
+    closed = list_closed()
+    realized = sum((p.realized_pnl or 0.0) for p in closed)
+    invested = sum(p.qty * p.entry_price for p in open_pos)
+    unrealized = 0.0
+    if price_lookup:
+        for p in open_pos:
+            if p.code in price_lookup:
+                unrealized += (price_lookup[p.code] - p.entry_price) * p.qty
+    return {
+        "open_count": float(len(open_pos)),
+        "closed_count": float(len(closed)),
+        "invested_cost": float(invested),
+        "unrealized_pnl": float(unrealized),
+        "realized_pnl": float(realized),
+    }

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,61 @@
+"""portfolio.state テスト."""
+
+from __future__ import annotations
+
+import warnings
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.portfolio import (
+    close_position,
+    list_open,
+    open_position,
+    portfolio_summary,
+)
+from quantmind.storage import init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def test_open_close_pnl() -> None:
+    p = open_position("1234", 100, 500.0, entry_date=date(2026, 4, 1), scenario_id="scn-1")
+    assert p.status == "open"
+    closed = close_position(p.id, 600.0, exit_date=date(2026, 4, 5))
+    assert closed.status == "closed"
+    assert closed.realized_pnl == pytest.approx(10000.0)
+
+
+def test_max_positions_warn() -> None:
+    for i in range(5):
+        open_position(f"100{i}", 100, 500.0)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        open_position("9999", 100, 500.0)  # 6個目で警告
+        assert any("最大同時保有数" in str(x.message) for x in w)
+    assert len(list_open()) == 6  # 拒否はせず通知のみ
+
+
+def test_summary_with_price_lookup() -> None:
+    p = open_position("1234", 100, 500.0)
+    open_position("5678", 100, 300.0)
+    summary = portfolio_summary(price_lookup={"1234": 550.0, "5678": 250.0})
+    # 1234: +50*100 = +5000, 5678: -50*100 = -5000 → 0
+    assert summary["unrealized_pnl"] == pytest.approx(0.0)
+    assert summary["open_count"] == 2.0
+    assert summary["invested_cost"] == pytest.approx(80000.0)
+    # close one
+    close_position(p.id, 600.0)
+    summary2 = portfolio_summary()
+    assert summary2["realized_pnl"] == pytest.approx(10000.0)
+    assert summary2["closed_count"] == 1.0
+
+
+def test_close_unknown_raises() -> None:
+    with pytest.raises(ValueError):
+        close_position("non-existent-id", 100.0)


### PR DESCRIPTION
## Summary
- `positions` テーブル CRUD: `open_position` / `close_position` / `list_open` / `list_closed`
- 実現損益・評価損益計算、`portfolio_summary` で集計
- 最大同時保有数 (`MAX_POSITIONS=5`) 超過は warning（拒否はしない）
- 反証シナリオID を `scenario_id` で保持
- CLI: `python -m quantmind.portfolio open/close/list/history/summary`

Closes #14

## Test plan
- [x] open → close → realized_pnl 計算
- [x] 最大保有超過時に warning
- [x] portfolio_summary で価格lookupによる評価損益
- [x] 存在しないIDの close で ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)