### PR TITLE
[#5] TDnetコレクタ（適時開示）

### DIFF
--- a/src/quantmind/data/tdnet/__init__.py
+++ b/src/quantmind/data/tdnet/__init__.py
@@ -1,0 +1,14 @@
+"""TDnet 適時開示コレクタ."""
+
+from quantmind.data.tdnet.classifier import classify_title
+from quantmind.data.tdnet.client import TdnetClient, TdnetEntry
+from quantmind.data.tdnet.frequency import disclosure_frequency
+from quantmind.data.tdnet.ingest import ingest_entries
+
+__all__ = [
+    "TdnetClient",
+    "TdnetEntry",
+    "classify_title",
+    "disclosure_frequency",
+    "ingest_entries",
+]

--- a/src/quantmind/data/tdnet/__main__.py
+++ b/src/quantmind/data/tdnet/__main__.py
@@ -1,0 +1,28 @@
+"""``python -m quantmind.data.tdnet fetch --date YYYY-MM-DD`` CLI."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from quantmind.data.tdnet.client import TdnetClient
+from quantmind.data.tdnet.ingest import ingest_entries
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.data.tdnet")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    f = sub.add_parser("fetch", help="指定日のTDnet開示を収集")
+    f.add_argument("--date", required=True, help="YYYY-MM-DD")
+    args = parser.parse_args(argv)
+
+    target = date.fromisoformat(args.date)
+    client = TdnetClient()
+    entries = client.list_for_date(target)
+    n = ingest_entries(entries)
+    print(f"fetched {len(entries)} entries; inserted {n} new")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/data/tdnet/classifier.py
+++ b/src/quantmind/data/tdnet/classifier.py
@@ -1,0 +1,30 @@
+"""タイトル文字列から開示種別を簡易分類する."""
+
+from __future__ import annotations
+
+# (キーワード, doc_type) の優先順位リスト
+RULES: list[tuple[str, str]] = [
+    ("業績予想の修正", "forecast_revision"),
+    ("業績予想修正", "forecast_revision"),
+    ("配当予想の修正", "dividend_revision"),
+    ("自己株式", "buyback"),
+    ("自己株取得", "buyback"),
+    ("株式分割", "stock_split"),
+    ("第三者割当", "third_party_alloc"),
+    ("公開買付", "tender_offer"),
+    ("ＴＯＢ", "tender_offer"),
+    ("M&A", "m_a"),
+    ("吸収合併", "m_a"),
+    ("株式交換", "m_a"),
+    ("決算短信", "earnings"),
+    ("四半期報告書", "quarterly_report"),
+    ("有価証券報告書", "yuho"),
+    ("月次", "monthly"),
+]
+
+
+def classify_title(title: str) -> str:
+    for kw, doc_type in RULES:
+        if kw in title:
+            return doc_type
+    return "other"

--- a/src/quantmind/data/tdnet/client.py
+++ b/src/quantmind/data/tdnet/client.py
@@ -1,0 +1,114 @@
+"""TDnet 公式サイトの日次一覧をスクレイピングする最小クライアント.
+
+公式 API は無いため `https://www.release.tdnet.info/inbs/I_list_NNN_YYYYMMDD.html`
+（NNN はページ番号）の HTML を順次取得して解析する。
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+from urllib.parse import urljoin
+
+DEFAULT_UA = (
+    "QuantMindBot/0.1 (+https://github.com/ysj101/QuantMind; personal research use)"
+)
+BASE_URL = "https://www.release.tdnet.info/inbs/"
+
+
+@dataclass(frozen=True)
+class TdnetEntry:
+    code: str
+    name: str
+    title: str
+    disclosed_at: datetime
+    pdf_url: str | None
+    raw_id: str  # ソース上の一意ID（時刻+code+title hash 等）
+
+
+def _build_list_url(d: date, page: int) -> str:
+    return f"{BASE_URL}I_list_{page:03d}_{d:%Y%m%d}.html"
+
+
+class TdnetClient:
+    """日次の TDnet 開示一覧を取得する."""
+
+    def __init__(
+        self,
+        user_agent: str = DEFAULT_UA,
+        request_interval: float = 1.0,
+        max_pages: int = 20,
+        fetcher: Any = None,
+    ) -> None:
+        self.user_agent = user_agent
+        self.request_interval = request_interval
+        self.max_pages = max_pages
+        self._fetcher = fetcher  # テスト注入用 callable: (url) -> str | None
+
+    def _fetch(self, url: str) -> str | None:
+        if self._fetcher is not None:
+            return self._fetcher(url)
+        import requests
+
+        resp = requests.get(url, headers={"User-Agent": self.user_agent}, timeout=30)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.text
+
+    def list_for_date(self, d: date) -> list[TdnetEntry]:
+        entries: list[TdnetEntry] = []
+        for page in range(1, self.max_pages + 1):
+            url = _build_list_url(d, page)
+            html = self._fetch(url)
+            if html is None:
+                break
+            page_entries = parse_tdnet_list(html, d, base_url=url)
+            if not page_entries:
+                break
+            entries.extend(page_entries)
+            time.sleep(self.request_interval)
+        return entries
+
+
+_ROW_RE = re.compile(
+    r'<td[^>]*>\s*(?P<time>\d{1,2}:\d{2})\s*</td>'
+    r'.*?<td[^>]*>\s*(?P<code>\d{4,5})\s*</td>'
+    r'.*?<td[^>]*>\s*(?P<name>[^<]+?)\s*</td>'
+    r'.*?<a[^>]*href="(?P<pdf>[^"]+\.pdf)"[^>]*>\s*(?P<title>[^<]+?)\s*</a>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def parse_tdnet_list(html: str, d: date, *, base_url: str) -> list[TdnetEntry]:
+    """TDnet 日次一覧 HTML から TdnetEntry を抽出する.
+
+    HTML 構造変化に対する頑健性は完全ではない。テスト注入可能な
+    fetcher で代替できるよう設計しているため、本番投入時は `fetcher`
+    を差し替えることを推奨する。
+    """
+    out: list[TdnetEntry] = []
+    for m in _ROW_RE.finditer(html):
+        hour, minute = m.group("time").split(":")
+        disclosed_at = datetime(d.year, d.month, d.day, int(hour), int(minute))
+        code = m.group("code").strip()
+        if len(code) == 5 and code.endswith("0"):
+            # 5桁コードは末尾0除去で4桁化（東証拡張表記対応）
+            code = code[:4]
+        title = m.group("title").strip()
+        pdf = urljoin(base_url, m.group("pdf").strip())
+        raw_id = f"tdnet:{disclosed_at:%Y%m%d%H%M}:{code}:{abs(hash(title)) & 0xFFFFFF:06x}"
+        out.append(
+            TdnetEntry(
+                code=code,
+                name=m.group("name").strip(),
+                title=title,
+                disclosed_at=disclosed_at,
+                pdf_url=pdf,
+                raw_id=raw_id,
+            )
+        )
+    return out

--- a/src/quantmind/data/tdnet/frequency.py
+++ b/src/quantmind/data/tdnet/frequency.py
@@ -1,0 +1,36 @@
+"""IR 発信頻度メタ観察（銘柄別の発信数時系列）."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+
+from quantmind.storage import get_conn
+
+
+def disclosure_frequency(
+    code: str,
+    *,
+    end: date | None = None,
+    days: int = 30,
+) -> pd.DataFrame:
+    """指定銘柄の直近 ``days`` 日間の日次開示数を返す.
+
+    Returns
+    -------
+    pandas.DataFrame
+        列: ``date``, ``count``。当該期間のすべての日（0件の日も含む）。
+    """
+    end_d = end or date.today()
+    start_d = end_d - timedelta(days=days - 1)
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT CAST(disclosed_at AS DATE) AS d, COUNT(*) FROM disclosures "
+            "WHERE code=? AND CAST(disclosed_at AS DATE) BETWEEN ? AND ? "
+            "GROUP BY d ORDER BY d",
+            [code, start_d, end_d],
+        ).fetchall()
+    counts = {r[0]: int(r[1]) for r in rows}
+    all_days = [start_d + timedelta(days=i) for i in range(days)]
+    return pd.DataFrame({"date": all_days, "count": [counts.get(d, 0) for d in all_days]})

--- a/src/quantmind/data/tdnet/ingest.py
+++ b/src/quantmind/data/tdnet/ingest.py
@@ -1,0 +1,41 @@
+"""TdnetEntry を disclosures テーブルへ冪等投入."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+from quantmind.data.tdnet.classifier import classify_title
+from quantmind.data.tdnet.client import TdnetEntry
+from quantmind.storage import get_conn
+
+
+def ingest_entries(entries: Iterable[TdnetEntry]) -> int:
+    """既存IDをスキップして新規のみ INSERT。挿入件数を返す."""
+    inserted = 0
+    with get_conn() as conn:
+        for e in entries:
+            existing = conn.execute(
+                "SELECT 1 FROM disclosures WHERE id=?", [e.raw_id]
+            ).fetchone()
+            if existing is not None:
+                continue
+            doc_type = classify_title(e.title)
+            conn.execute(
+                "INSERT INTO disclosures(id, code, source, doc_type, title, disclosed_at, url, raw_json) "
+                "VALUES (?, ?, 'tdnet', ?, ?, ?, ?, ?)",
+                [
+                    e.raw_id,
+                    e.code,
+                    doc_type,
+                    e.title,
+                    e.disclosed_at,
+                    e.pdf_url,
+                    json.dumps(
+                        {"name": e.name, "raw_id": e.raw_id},
+                        ensure_ascii=False,
+                    ),
+                ],
+            )
+            inserted += 1
+    return inserted

--- a/tests/test_tdnet.py
+++ b/tests/test_tdnet.py
@@ -1,0 +1,120 @@
+"""TDnet コレクタのテスト."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.data.tdnet import (
+    TdnetClient,
+    classify_title,
+    disclosure_frequency,
+    ingest_entries,
+)
+from quantmind.data.tdnet.client import TdnetEntry, parse_tdnet_list
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+SAMPLE_HTML_PAGE_1 = """
+<html><body><table>
+  <tr>
+    <td>15:00</td><td>1234</td><td>テスト株式会社</td>
+    <td><a href="012345/00012345.pdf">2026年3月期決算短信〔日本基準〕(連結)</a></td>
+  </tr>
+  <tr>
+    <td>15:30</td><td>5678</td><td>サンプルHD</td>
+    <td><a href="012346/00012346.pdf">業績予想の修正に関するお知らせ</a></td>
+  </tr>
+  <tr>
+    <td>16:00</td><td>1234</td><td>テスト株式会社</td>
+    <td><a href="012347/00012347.pdf">自己株式の取得状況に関するお知らせ</a></td>
+  </tr>
+</table></body></html>
+"""
+
+SAMPLE_HTML_PAGE_EMPTY = "<html><body><table></table></body></html>"
+
+
+def test_parse_tdnet_list_extracts_rows() -> None:
+    entries = parse_tdnet_list(SAMPLE_HTML_PAGE_1, date(2026, 4, 30), base_url="https://x/")
+    assert len(entries) == 3
+    assert entries[0].code == "1234"
+    assert "決算短信" in entries[0].title
+    assert entries[0].pdf_url is not None and entries[0].pdf_url.endswith(".pdf")
+
+
+def test_classify_title() -> None:
+    assert classify_title("2026年3月期決算短信") == "earnings"
+    assert classify_title("業績予想の修正") == "forecast_revision"
+    assert classify_title("自己株式の取得状況") == "buyback"
+    assert classify_title("ナイトセッションのお知らせ") == "other"
+
+
+def test_client_with_fake_fetcher() -> None:
+    pages = {
+        # page 001 returns 3 entries, page 002 returns empty
+    }
+
+    def fetcher(url: str) -> str | None:
+        if url.endswith("I_list_001_20260430.html"):
+            return SAMPLE_HTML_PAGE_1
+        if url.endswith("I_list_002_20260430.html"):
+            return SAMPLE_HTML_PAGE_EMPTY
+        return None
+
+    pages_used = pages  # silence unused
+    del pages_used
+    client = TdnetClient(request_interval=0.0, fetcher=fetcher)
+    entries = client.list_for_date(date(2026, 4, 30))
+    assert len(entries) == 3
+
+
+def test_ingest_idempotent() -> None:
+    e1 = TdnetEntry(
+        code="1234",
+        name="テスト",
+        title="2026年3月期決算短信",
+        disclosed_at=__import__("datetime").datetime(2026, 4, 30, 15, 0),
+        pdf_url="https://x/a.pdf",
+        raw_id="tdnet:test:1",
+    )
+    e2 = TdnetEntry(
+        code="5678",
+        name="サンプル",
+        title="業績予想の修正",
+        disclosed_at=__import__("datetime").datetime(2026, 4, 30, 15, 30),
+        pdf_url="https://x/b.pdf",
+        raw_id="tdnet:test:2",
+    )
+    assert ingest_entries([e1, e2]) == 2
+    # 2回目は冪等
+    assert ingest_entries([e1, e2]) == 0
+    with get_conn(read_only=True) as conn:
+        n = conn.execute("SELECT COUNT(*) FROM disclosures").fetchone()
+    assert n is not None and n[0] == 2
+
+
+def test_disclosure_frequency_zero_padded() -> None:
+    e = TdnetEntry(
+        code="1234",
+        name="テスト",
+        title="決算短信",
+        disclosed_at=__import__("datetime").datetime(2026, 4, 28, 15, 0),
+        pdf_url=None,
+        raw_id="tdnet:freq:1",
+    )
+    ingest_entries([e])
+    df = disclosure_frequency("1234", end=date(2026, 4, 30), days=5)
+    assert len(df) == 5
+    # 4/28 のみ count=1
+    counts = dict(zip(df["date"], df["count"], strict=True))
+    assert counts[date(2026, 4, 28)] == 1
+    assert counts[date(2026, 4, 30)] == 0


### PR DESCRIPTION
## Summary
- TDnet 公式 HTML 一覧をページネーション取得する `TdnetClient`（`fetcher` 注入で代替エンドポイント差替え可）
- タイトルから開示種別を簡易分類 (`classify_title`)
- `disclosures` テーブルへ冪等投入
- 発信頻度メタ観察用の `disclosure_frequency()` 集計（直近N日）
- CLI: `python -m quantmind.data.tdnet fetch --date YYYY-MM-DD`

Closes #5

## Test plan
- [x] HTML パーサがサンプル3行から3エントリ抽出
- [x] 分類器が代表ケース正しい
- [x] 冪等 ingest（2回目は0件追加）
- [x] frequency が0埋めで完全な日次列を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)