### PR TITLE
[#4] EDINETコレクタ（財務・役員情報）

### DIFF
--- a/src/quantmind/data/edinet/__init__.py
+++ b/src/quantmind/data/edinet/__init__.py
@@ -1,0 +1,17 @@
+"""EDINET API クライアントとXBRL/PDF抽出."""
+
+from quantmind.data.edinet.client import EdinetClient, EdinetDocument
+from quantmind.data.edinet.financials import (
+    extract_financials_from_xbrl,
+    upsert_financials,
+)
+from quantmind.data.edinet.officers import extract_officers_from_text, upsert_officers
+
+__all__ = [
+    "EdinetClient",
+    "EdinetDocument",
+    "extract_financials_from_xbrl",
+    "extract_officers_from_text",
+    "upsert_financials",
+    "upsert_officers",
+]

--- a/src/quantmind/data/edinet/__main__.py
+++ b/src/quantmind/data/edinet/__main__.py
@@ -1,0 +1,51 @@
+"""EDINET CLI: list / download / extract."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import date
+from pathlib import Path
+
+from quantmind.data.edinet.client import EdinetClient
+from quantmind.data.edinet.financials import (
+    extract_financials_from_xbrl,
+    upsert_financials,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.data.edinet")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    ls = sub.add_parser("list", help="指定日の提出書類を一覧")
+    ls.add_argument("--date", required=True)
+
+    dl = sub.add_parser("download", help="書類本体DL")
+    dl.add_argument("doc_id")
+    dl.add_argument("--kind", choices=["xbrl", "pdf"], default="xbrl")
+    dl.add_argument("--out", default="./.cache/edinet")
+
+    ex = sub.add_parser("extract-financials", help="ローカルXBRLから財務指標抽出")
+    ex.add_argument("path")
+    ex.add_argument("--code", required=True)
+    ex.add_argument("--period", required=True)
+
+    args = parser.parse_args(argv)
+    api_key = os.environ.get("EDINET_API_KEY")
+    if args.cmd == "list":
+        client = EdinetClient(api_key=api_key)
+        for d in client.list_documents(date.fromisoformat(args.date)):
+            print(f"{d.doc_id}\t{d.code or '----'}\t{d.doc_type_code}\t{d.doc_description}")
+    elif args.cmd == "download":
+        client = EdinetClient(api_key=api_key)
+        path = client.download(args.doc_id, kind=args.kind, out_dir=Path(args.out))
+        print(f"saved {path}")
+    elif args.cmd == "extract-financials":
+        values = extract_financials_from_xbrl(Path(args.path))
+        upsert_financials(args.code, args.period, values)
+        print(values)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/data/edinet/client.py
+++ b/src/quantmind/data/edinet/client.py
@@ -1,0 +1,110 @@
+"""EDINET 書類API クライアント.
+
+EDINET は書類一覧と書類本体（XBRL/PDF）を取得するエンドポイントを提供する。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+DEFAULT_UA = (
+    "QuantMindBot/0.1 (+https://github.com/ysj101/QuantMind; personal research use)"
+)
+LIST_URL = "https://api.edinet-fsa.go.jp/api/v2/documents.json"
+DOC_URL = "https://api.edinet-fsa.go.jp/api/v2/documents/{doc_id}"
+
+
+@dataclass(frozen=True)
+class EdinetDocument:
+    doc_id: str
+    code: str | None  # 4桁証券コード（無い書類もある）
+    edinet_code: str
+    filer_name: str
+    doc_type_code: str
+    doc_description: str
+    submit_datetime: str  # ISO8601 文字列
+    raw: dict[str, Any]
+
+
+class EdinetClient:
+    """EDINET API ラッパ.
+
+    ``fetcher`` を注入することで実通信なしのテストが可能。
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        user_agent: str = DEFAULT_UA,
+        fetcher: Any = None,
+        binary_fetcher: Any = None,
+    ) -> None:
+        self.api_key = api_key
+        self.user_agent = user_agent
+        self._fetcher = fetcher
+        self._binary_fetcher = binary_fetcher
+
+    def _get_json(self, url: str, params: dict[str, str]) -> dict[str, Any]:
+        if self._fetcher is not None:
+            return self._fetcher(url, params)
+        import requests
+
+        if self.api_key:
+            params = {**params, "Subscription-Key": self.api_key}
+        resp = requests.get(url, params=params, headers={"User-Agent": self.user_agent}, timeout=30)
+        resp.raise_for_status()
+        data: dict[str, Any] = resp.json()
+        return data
+
+    def _get_binary(self, url: str, params: dict[str, str]) -> bytes:
+        if self._binary_fetcher is not None:
+            return self._binary_fetcher(url, params)
+        import requests
+
+        if self.api_key:
+            params = {**params, "Subscription-Key": self.api_key}
+        resp = requests.get(url, params=params, headers={"User-Agent": self.user_agent}, timeout=60)
+        resp.raise_for_status()
+        return resp.content
+
+    def list_documents(self, d: date) -> list[EdinetDocument]:
+        """指定日に提出された全書類のメタデータを返す."""
+        data = self._get_json(LIST_URL, {"date": d.isoformat(), "type": "2"})
+        results = data.get("results", []) or []
+        out: list[EdinetDocument] = []
+        for r in results:
+            out.append(
+                EdinetDocument(
+                    doc_id=r.get("docID", ""),
+                    code=(r.get("secCode") or "").strip()[:4] or None,
+                    edinet_code=r.get("edinetCode", ""),
+                    filer_name=r.get("filerName", ""),
+                    doc_type_code=r.get("docTypeCode", ""),
+                    doc_description=r.get("docDescription", ""),
+                    submit_datetime=r.get("submitDateTime", ""),
+                    raw=r,
+                )
+            )
+        return out
+
+    def download(self, doc_id: str, kind: str = "xbrl", out_dir: Path | None = None) -> Path:
+        """書類本体をダウンロード.
+
+        ``kind``:
+        - ``xbrl``  : XBRL（type=1, ZIP）
+        - ``pdf``   : PDF（type=2）
+        """
+        type_code = {"xbrl": "1", "pdf": "2"}[kind]
+        url = DOC_URL.format(doc_id=doc_id)
+        body = self._get_binary(url, {"type": type_code})
+        out_dir = out_dir or Path("./.cache/edinet")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        suffix = ".zip" if kind == "xbrl" else ".pdf"
+        path = out_dir / f"{doc_id}{suffix}"
+        # 既存ファイルはスキップ（冪等）
+        if not path.exists():
+            path.write_bytes(body)
+        return path

--- a/src/quantmind/data/edinet/financials.py
+++ b/src/quantmind/data/edinet/financials.py
@@ -1,0 +1,111 @@
+"""XBRL から主要財務指標を抽出する最小実装.
+
+完全な XBRL タクソノミ対応は重いため、頻出タグの定数マッピングで
+売上高・営業利益・純利益・総資産・純資産を取得する単純実装。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import zipfile
+from pathlib import Path
+
+from quantmind.storage import get_conn
+
+# 主要 IFRS / 日本基準タグ（ローカル名）の優先候補
+TAG_MAPPING: dict[str, list[str]] = {
+    "revenue": ["NetSales", "Revenue", "OperatingRevenue", "NetSalesIFRS"],
+    "operating_income": ["OperatingIncome", "OperatingProfit", "OperatingIncomeLoss"],
+    "net_income": ["NetIncome", "ProfitLoss", "NetIncomeIFRS"],
+    "total_assets": ["Assets", "TotalAssets"],
+    "total_equity": ["NetAssets", "Equity", "TotalEquity"],
+}
+
+_TAG_RE = re.compile(
+    r"<(?:[a-zA-Z0-9_-]+:)?(?P<tag>[A-Za-z0-9_]+)(?P<attrs>[^>]*)>(?P<val>[^<]+)</",
+    re.DOTALL,
+)
+_CONTEXT_RE = re.compile(r'contextRef="([^"]+)"')
+
+
+def _read_xbrl_text(path: Path) -> str:
+    """XBRL ZIP からメインの XBRL テキストを連結して返す。"""
+    if path.is_dir():
+        files = sorted(path.rglob("*.xbrl"))
+        return "\n".join(p.read_text(encoding="utf-8", errors="ignore") for p in files)
+    if path.suffix == ".zip":
+        with zipfile.ZipFile(path) as zf:
+            chunks: list[str] = []
+            for name in zf.namelist():
+                if name.lower().endswith(".xbrl"):
+                    chunks.append(zf.read(name).decode("utf-8", errors="ignore"))
+            return "\n".join(chunks)
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def extract_financials_from_xbrl(path_or_text: Path | str) -> dict[str, float | None]:
+    """XBRL から主要指標を抽出.
+
+    ``path_or_text`` がパスならファイルから、文字列ならその文字列を
+    XBRL 本文として解析する。
+    """
+    text = _read_xbrl_text(path_or_text) if isinstance(path_or_text, Path) else path_or_text
+
+    found: dict[str, float | None] = {k: None for k in TAG_MAPPING}
+    for m in _TAG_RE.finditer(text):
+        tag = m.group("tag")
+        attrs = m.group("attrs")
+        ctx_m = _CONTEXT_RE.search(attrs)
+        # 当期連結値を優先（contextRef が CurrentYear* / Consolidated* を含むもの）
+        ctx = ctx_m.group(1) if ctx_m else ""
+        if ctx and "Prior" in ctx:
+            continue
+        val_str = m.group("val").strip().replace(",", "")
+        try:
+            val = float(val_str)
+        except ValueError:
+            continue
+        for metric, candidates in TAG_MAPPING.items():
+            if found[metric] is not None:
+                continue
+            if tag in candidates:
+                found[metric] = val
+                break
+    return found
+
+
+def upsert_financials(
+    code: str,
+    fiscal_period: str,
+    values: dict[str, float | None],
+    *,
+    raw_json: dict | None = None,
+) -> None:
+    payload = {
+        "revenue": values.get("revenue"),
+        "operating_income": values.get("operating_income"),
+        "net_income": values.get("net_income"),
+        "total_assets": values.get("total_assets"),
+        "total_equity": values.get("total_equity"),
+    }
+    raw = json.dumps(raw_json or values, ensure_ascii=False)
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO financials(code, fiscal_period, revenue, operating_income, net_income, "
+            "total_assets, total_equity, raw_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(code, fiscal_period) DO UPDATE SET "
+            "revenue=excluded.revenue, operating_income=excluded.operating_income, "
+            "net_income=excluded.net_income, total_assets=excluded.total_assets, "
+            "total_equity=excluded.total_equity, raw_json=excluded.raw_json",
+            [
+                code,
+                fiscal_period,
+                payload["revenue"],
+                payload["operating_income"],
+                payload["net_income"],
+                payload["total_assets"],
+                payload["total_equity"],
+                raw,
+            ],
+        )

--- a/src/quantmind/data/edinet/officers.py
+++ b/src/quantmind/data/edinet/officers.py
@@ -1,0 +1,93 @@
+"""有価証券報告書から役員情報・大株主構成を抽出する.
+
+XBRL タクソノミに完全準拠せず、テキスト中の代表的な見出しと表組みを
+正規表現で抽出する軽量実装。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+from quantmind.storage import get_conn
+
+# 役員行: 名前は「姓 名」のように内部に空白を含むケースを許容（最大2語）
+# 例: "山田 太郎 代表取締役社長 ..."
+_OFFICER_LINE_RE = re.compile(
+    r"^\s*(?P<name>[^\s\d]{1,12}(?:\s+[^\s\d]{1,12})?)\s+"
+    r"(?P<role>(?:代表取締役[^\s]*社長|代表取締役|取締役|常務|専務|社長|"
+    r"監査役|執行役員)[^\s]*?)\s+"
+    r"(?P<bio>[^\n]{10,200})",
+    re.MULTILINE,
+)
+
+# 大株主行: 個人なら「姓 名」、法人なら一語の名称。所有株数・割合が続く。
+_HOLDER_LINE_RE = re.compile(
+    r"^\s*(?P<name>[^\s\d]{2,40}(?:\s+[^\s\d]{1,12})?)\s+"
+    r"(?P<shares>[\d,]+)\s+(?P<pct>\d{1,2}\.\d{1,3})\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class OfficerRecord:
+    name: str
+    role: str
+    bio: str
+    holdings_pct: float | None
+
+
+def extract_officers_from_text(text: str) -> list[OfficerRecord]:
+    """テキスト本文から役員候補と大株主候補を統合して返す.
+
+    完全な精度は出ないが、社長交代・大株主変動を後段の LLM で再評価する
+    入力として十分な粒度を確保する。
+    """
+    out: list[OfficerRecord] = []
+    holders = {m.group("name"): float(m.group("pct")) for m in _HOLDER_LINE_RE.finditer(text)}
+    seen: set[tuple[str, str]] = set()
+    for m in _OFFICER_LINE_RE.finditer(text):
+        key = (m.group("name"), m.group("role"))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            OfficerRecord(
+                name=m.group("name").strip(),
+                role=m.group("role").strip(),
+                bio=m.group("bio").strip(),
+                holdings_pct=holders.get(m.group("name").strip()),
+            )
+        )
+    # 役員リストになく大株主だけ取れた個人/法人もエントリ追加
+    for name, pct in holders.items():
+        if not any(o.name == name for o in out):
+            out.append(OfficerRecord(name=name, role="shareholder", bio="", holdings_pct=pct))
+    return out
+
+
+def upsert_officers(code: str, fiscal_period: str, records: list[OfficerRecord]) -> int:
+    n = 0
+    with get_conn() as conn:
+        # 同じ code/fiscal_period の既存行は一旦削除して再挿入（簡易的な冪等性）
+        conn.execute(
+            "DELETE FROM officers WHERE code=? AND fiscal_period=?",
+            [code, fiscal_period],
+        )
+        for r in records:
+            conn.execute(
+                "INSERT INTO officers(code, fiscal_period, name, role, bio, holdings_pct, raw_json) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    code,
+                    fiscal_period,
+                    r.name,
+                    r.role,
+                    r.bio,
+                    r.holdings_pct,
+                    json.dumps(r.__dict__, ensure_ascii=False),
+                ],
+            )
+            n += 1
+    return n

--- a/tests/test_edinet.py
+++ b/tests/test_edinet.py
@@ -1,0 +1,136 @@
+"""EDINET コレクタのテスト."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.data.edinet.client import EdinetClient
+from quantmind.data.edinet.financials import (
+    extract_financials_from_xbrl,
+    upsert_financials,
+)
+from quantmind.data.edinet.officers import (
+    extract_officers_from_text,
+    upsert_officers,
+)
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+SAMPLE_LIST = {
+    "results": [
+        {
+            "docID": "S100ABCD",
+            "secCode": "12340",
+            "edinetCode": "E12345",
+            "filerName": "テスト株式会社",
+            "docTypeCode": "120",
+            "docDescription": "有価証券報告書（第10期）",
+            "submitDateTime": "2026-04-30 09:00",
+        }
+    ]
+}
+
+SAMPLE_XBRL = """<xbrl>
+<jpcrp:NetSales contextRef="CurrentYearConsolidatedDuration_NonConsolidatedMember">1500000000</jpcrp:NetSales>
+<jpcrp:NetSales contextRef="PriorYearConsolidatedDuration">1300000000</jpcrp:NetSales>
+<jpcrp:OperatingIncome contextRef="CurrentYearConsolidatedDuration">120000000</jpcrp:OperatingIncome>
+<jpcrp:NetIncome contextRef="CurrentYearConsolidatedDuration">80000000</jpcrp:NetIncome>
+<jpcrp:Assets contextRef="CurrentYearConsolidatedInstant">5000000000</jpcrp:Assets>
+<jpcrp:NetAssets contextRef="CurrentYearConsolidatedInstant">3000000000</jpcrp:NetAssets>
+</xbrl>"""
+
+SAMPLE_OFFICERS_TEXT = """
+役員の状況
+山田 太郎 代表取締役社長 1980年4月当社入社、2020年6月より現職に就任
+鈴木 花子 取締役 経理畑出身でCFOとして財務戦略を担当している
+佐藤 一郎 監査役 弁護士として企業法務に長年従事してきた経歴を有する
+大株主の状況
+山田 太郎 1,500,000 12.500
+日本マスタートラスト信託銀行株式会社 800,000 6.667
+"""
+
+
+def test_list_documents_with_fake_fetcher() -> None:
+    def fetcher(url: str, params: dict[str, str]) -> dict:
+        return SAMPLE_LIST
+
+    client = EdinetClient(fetcher=fetcher)
+    docs = client.list_documents(date(2026, 4, 30))
+    assert len(docs) == 1
+    assert docs[0].code == "1234"
+    assert docs[0].doc_type_code == "120"
+
+
+def test_extract_financials_picks_current_year() -> None:
+    values = extract_financials_from_xbrl(SAMPLE_XBRL)
+    assert values["revenue"] == 1500000000.0
+    assert values["operating_income"] == 120000000.0
+    assert values["net_income"] == 80000000.0
+    assert values["total_assets"] == 5000000000.0
+    assert values["total_equity"] == 3000000000.0
+
+
+def test_upsert_financials_idempotent() -> None:
+    values = extract_financials_from_xbrl(SAMPLE_XBRL)
+    upsert_financials("1234", "2026FY", values)
+    upsert_financials("1234", "2026FY", values)
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT revenue, total_assets FROM financials WHERE code='1234' AND fiscal_period='2026FY'"
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == 1500000000.0
+
+
+def test_extract_officers_finds_president_and_holders() -> None:
+    records = extract_officers_from_text(SAMPLE_OFFICERS_TEXT)
+    names = {r.name for r in records}
+    assert "山田 太郎" in names
+    # 大株主構成の保有率もエンリッチされる
+    yamada = next(r for r in records if r.name == "山田 太郎")
+    assert yamada.holdings_pct == 12.5
+
+
+def test_upsert_officers_replaces_period() -> None:
+    records = extract_officers_from_text(SAMPLE_OFFICERS_TEXT)
+    n1 = upsert_officers("1234", "2026FY", records)
+    n2 = upsert_officers("1234", "2026FY", records)
+    assert n1 == n2
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM officers WHERE code='1234' AND fiscal_period='2026FY'"
+        ).fetchone()
+    assert rows is not None
+    assert rows[0] == n1
+
+
+def test_e2e_one_stock(tmp_path: Path) -> None:
+    """1銘柄分の E2E: list → extract → upsert."""
+    def fetcher(url: str, params: dict[str, str]) -> dict:
+        return SAMPLE_LIST
+
+    client = EdinetClient(fetcher=fetcher)
+    docs = client.list_documents(date(2026, 4, 30))
+    assert len(docs) == 1
+    code = docs[0].code
+    assert code == "1234"
+
+    values = extract_financials_from_xbrl(SAMPLE_XBRL)
+    upsert_financials(code, "2026FY", values)
+    officers = extract_officers_from_text(SAMPLE_OFFICERS_TEXT)
+    upsert_officers(code, "2026FY", officers)
+
+    with get_conn(read_only=True) as conn:
+        n_fin = conn.execute("SELECT COUNT(*) FROM financials WHERE code=?", [code]).fetchone()
+        n_off = conn.execute("SELECT COUNT(*) FROM officers WHERE code=?", [code]).fetchone()
+    assert n_fin is not None and n_fin[0] == 1
+    assert n_off is not None and n_off[0] >= 1


### PR DESCRIPTION
## Summary
- `EdinetClient` で書類一覧/本体取得（API キーは `EDINET_API_KEY` 環境変数 / `fetcher` 注入で完全モック可）
- `extract_financials_from_xbrl`: 主要指標を抽出（PriorYear context を除外し当期値優先）
- `extract_officers_from_text`: 役員（代表取締役・社長・監査役 等）+ 大株主構成を抽出して結合
- `upsert_financials` / `upsert_officers` で `financials` / `officers` テーブルに冪等保存
- CLI: `python -m quantmind.data.edinet list/download/extract-financials`

Closes #4

## Test plan
- [x] サンプル書類一覧から `secCode=12340` → 4桁化 `1234` を確認
- [x] サンプル XBRL から売上/営業利益/純利益/総資産/純資産を抽出
- [x] 1銘柄分の E2E（list → extract → upsert）が financials/officers に反映
- [x] upsert 冪等性

🤖 Generated with [Claude Code](https://claude.com/claude-code)