### PR TITLE
[#6] 決算説明資料PDFコレクタ

### DIFF
--- a/src/quantmind/data/ir_docs/__init__.py
+++ b/src/quantmind/data/ir_docs/__init__.py
@@ -1,0 +1,11 @@
+"""決算説明資料 PDF コレクタ."""
+
+from quantmind.data.ir_docs.collector import IrDocsCollector, IrDocsResult
+from quantmind.data.ir_docs.registry import IrPageRegistry, RegistryEntry
+
+__all__ = [
+    "IrDocsCollector",
+    "IrDocsResult",
+    "IrPageRegistry",
+    "RegistryEntry",
+]

--- a/src/quantmind/data/ir_docs/__main__.py
+++ b/src/quantmind/data/ir_docs/__main__.py
@@ -1,0 +1,31 @@
+"""IR PDF 収集 CLI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from quantmind.data.ir_docs.collector import IrDocsCollector, upsert_ir_documents
+from quantmind.data.ir_docs.registry import IrPageRegistry
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.data.ir_docs")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    c = sub.add_parser("collect", help="IR ページから決算説明資料PDFを収集")
+    c.add_argument("--registry", required=True, help="レジストリ YAML パス")
+    c.add_argument("--codes", nargs="*", help="対象銘柄コード（省略時は全件）")
+
+    args = parser.parse_args(argv)
+    registry = IrPageRegistry.from_yaml(Path(args.registry))
+    collector = IrDocsCollector(registry)
+    results = collector.collect_for_codes(args.codes)
+    n = upsert_ir_documents(results)
+    print(f"collected {len(results)} entries; upserted {n} rows")
+    for r in results:
+        print(f"  {r.code}: status={r.extraction_status} url={r.pdf_url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/data/ir_docs/collector.py
+++ b/src/quantmind/data/ir_docs/collector.py
@@ -1,0 +1,142 @@
+"""IR ページから決算説明資料 PDF を収集してテキスト化する."""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+from quantmind.data.ir_docs.registry import IrPageRegistry, RegistryEntry
+from quantmind.storage import get_conn
+
+log = logging.getLogger(__name__)
+
+DEFAULT_KEYWORD = "決算説明"
+PDF_LINK_RE = re.compile(r'<a[^>]*href="(?P<href>[^"]+\.pdf)"[^>]*>(?P<text>[^<]+)</a>', re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class IrDocsResult:
+    code: str
+    pdf_url: str | None
+    extraction_status: str
+    body_text: str | None
+    error: str | None = None
+
+
+class IrDocsCollector:
+    """IR ページのHTMLを取得し、PDFを抽出してテキスト化する."""
+
+    def __init__(
+        self,
+        registry: IrPageRegistry,
+        *,
+        cache_dir: Path | None = None,
+        html_fetcher: Any = None,
+        pdf_fetcher: Any = None,
+        text_extractor: Any = None,
+    ) -> None:
+        self.registry = registry
+        self.cache_dir = cache_dir or Path("./.cache/ir_docs")
+        self._html_fetcher = html_fetcher
+        self._pdf_fetcher = pdf_fetcher
+        self._text_extractor = text_extractor
+
+    def _fetch_html(self, url: str) -> str:
+        if self._html_fetcher is not None:
+            text: str = self._html_fetcher(url)
+            return text
+        import requests
+
+        resp = requests.get(url, timeout=30, headers={"User-Agent": "QuantMindBot/0.1"})
+        resp.raise_for_status()
+        return resp.text
+
+    def _fetch_pdf(self, url: str) -> bytes:
+        if self._pdf_fetcher is not None:
+            data: bytes = self._pdf_fetcher(url)
+            return data
+        import requests
+
+        resp = requests.get(url, timeout=60, headers={"User-Agent": "QuantMindBot/0.1"})
+        resp.raise_for_status()
+        return resp.content
+
+    def _extract_text(self, pdf_bytes: bytes) -> str:
+        if self._text_extractor is not None:
+            extracted: str = self._text_extractor(pdf_bytes)
+            return extracted
+        import io
+
+        from pypdf import PdfReader
+
+        reader = PdfReader(io.BytesIO(pdf_bytes))
+        return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+    def _find_pdf_url(self, html: str, base_url: str, keyword: str) -> str | None:
+        for m in PDF_LINK_RE.finditer(html):
+            text = m.group("text")
+            if keyword in text:
+                return urljoin(base_url, m.group("href"))
+        return None
+
+    def collect_one(self, entry: RegistryEntry) -> IrDocsResult:
+        keyword = entry.pdf_link_pattern or DEFAULT_KEYWORD
+        try:
+            html = self._fetch_html(entry.ir_page_url)
+        except Exception as e:
+            log.warning("IR HTML fetch failed for %s: %s", entry.code, e)
+            return IrDocsResult(entry.code, None, "html_failed", None, error=str(e))
+
+        pdf_url = self._find_pdf_url(html, entry.ir_page_url, keyword)
+        if pdf_url is None:
+            log.warning("no PDF link with keyword %r on %s", keyword, entry.ir_page_url)
+            return IrDocsResult(entry.code, None, "not_found", None)
+
+        try:
+            pdf_bytes = self._fetch_pdf(pdf_url)
+        except Exception as e:
+            log.warning("PDF fetch failed for %s: %s", entry.code, e)
+            return IrDocsResult(entry.code, pdf_url, "pdf_failed", None, error=str(e))
+
+        try:
+            text = self._extract_text(pdf_bytes)
+        except Exception as e:
+            log.warning("PDF extract failed for %s: %s", entry.code, e)
+            return IrDocsResult(entry.code, pdf_url, "extract_failed", None, error=str(e))
+
+        return IrDocsResult(entry.code, pdf_url, "ok", text)
+
+    def collect_for_codes(self, codes: list[str] | None = None) -> list[IrDocsResult]:
+        target_codes = codes or self.registry.codes()
+        out: list[IrDocsResult] = []
+        for code in target_codes:
+            entry = self.registry.get(code)
+            if entry is None:
+                log.warning("IR registry missing code: %s", code)
+                continue
+            out.append(self.collect_one(entry))
+        return out
+
+
+def upsert_ir_documents(results: list[IrDocsResult], doc_type: str = "earnings_pres") -> int:
+    """ir_documents テーブルに UPSERT。挿入件数を返す."""
+    n = 0
+    today = date.today()
+    with get_conn() as conn:
+        for r in results:
+            doc_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{r.code}:{r.pdf_url or 'na'}:{today}"))
+            conn.execute(
+                "INSERT INTO ir_documents(id, code, doc_type, published_at, source_url, body_text, "
+                "extraction_status) VALUES (?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET body_text=excluded.body_text, "
+                "extraction_status=excluded.extraction_status",
+                [doc_id, r.code, doc_type, today, r.pdf_url, r.body_text, r.extraction_status],
+            )
+            n += 1
+    return n

--- a/src/quantmind/data/ir_docs/registry.py
+++ b/src/quantmind/data/ir_docs/registry.py
@@ -1,0 +1,41 @@
+"""IR ページ URL レジストリ（YAML ファイルベース）."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    code: str
+    ir_page_url: str
+    pdf_link_pattern: str | None = None  # 例: "決算説明" を含むリンクテキスト
+
+
+class IrPageRegistry:
+    """銘柄コード → IR ページ URL のレジストリ."""
+
+    def __init__(self, entries: dict[str, RegistryEntry]) -> None:
+        self.entries = entries
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> IrPageRegistry:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+        entries = {}
+        for row in data:
+            entry = RegistryEntry(
+                code=str(row["code"]),
+                ir_page_url=row["ir_page_url"],
+                pdf_link_pattern=row.get("pdf_link_pattern"),
+            )
+            entries[entry.code] = entry
+        return cls(entries)
+
+    def codes(self) -> list[str]:
+        return sorted(self.entries.keys())
+
+    def get(self, code: str) -> RegistryEntry | None:
+        return self.entries.get(code)

--- a/src/quantmind/data/ir_docs/registry_sample.yaml
+++ b/src/quantmind/data/ir_docs/registry_sample.yaml
@@ -1,0 +1,5 @@
+# IR ページ URL レジストリ（サンプル）。本番では各社の決算説明会資料ページURLを登録する。
+# ここはあくまで動作確認用。
+- code: "0000"
+  ir_page_url: "https://example.com/ir"
+  pdf_link_pattern: "決算説明"

--- a/tests/test_ir_docs.py
+++ b/tests/test_ir_docs.py
@@ -1,0 +1,141 @@
+"""IR PDF コレクタのテスト."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from quantmind.data.ir_docs.collector import (
+    IrDocsCollector,
+    IrDocsResult,
+    upsert_ir_documents,
+)
+from quantmind.data.ir_docs.registry import IrPageRegistry, RegistryEntry
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def _registry(codes: list[str]) -> IrPageRegistry:
+    return IrPageRegistry(
+        {c: RegistryEntry(code=c, ir_page_url=f"https://example.com/{c}/ir") for c in codes}
+    )
+
+
+def test_registry_yaml_loading(tmp_path: Path) -> None:
+    p = tmp_path / "reg.yaml"
+    p.write_text(
+        '- {code: "1234", ir_page_url: "https://x/1234"}\n'
+        '- {code: "5678", ir_page_url: "https://x/5678", pdf_link_pattern: "投資家向け"}\n',
+        encoding="utf-8",
+    )
+    reg = IrPageRegistry.from_yaml(p)
+    assert reg.codes() == ["1234", "5678"]
+    e = reg.get("5678")
+    assert e is not None
+    assert e.pdf_link_pattern == "投資家向け"
+
+
+SAMPLE_HTML = """
+<html><body>
+<a href="/decisions/2026q1.pdf">2026年3月期 決算説明資料</a>
+<a href="/decisions/notice.pdf">お知らせ</a>
+</body></html>
+"""
+
+
+def test_collect_one_happy_path() -> None:
+    reg = _registry(["1234"])
+    collector = IrDocsCollector(
+        reg,
+        html_fetcher=lambda url: SAMPLE_HTML,
+        pdf_fetcher=lambda url: b"DUMMY-PDF-BYTES",
+        text_extractor=lambda b: "決算説明資料の本文テキスト",
+    )
+    result = collector.collect_one(reg.get("1234"))  # type: ignore[arg-type]
+    assert result.extraction_status == "ok"
+    assert result.body_text and "本文" in result.body_text
+    assert result.pdf_url is not None
+    assert "2026q1.pdf" in result.pdf_url
+
+
+def test_collect_handles_missing_pdf_link(caplog: pytest.LogCaptureFixture) -> None:
+    reg = _registry(["1234"])
+    collector = IrDocsCollector(
+        reg,
+        html_fetcher=lambda url: "<html><a href='x.pdf'>関係ない資料</a></html>",
+    )
+    with caplog.at_level(logging.WARNING):
+        result = collector.collect_one(reg.get("1234"))  # type: ignore[arg-type]
+    assert result.extraction_status == "not_found"
+    assert any("no PDF link" in rec.message for rec in caplog.records)
+
+
+def test_collect_handles_pdf_fetch_failure(caplog: pytest.LogCaptureFixture) -> None:
+    reg = _registry(["1234"])
+
+    def failing(url: str) -> bytes:
+        raise RuntimeError("404")
+
+    collector = IrDocsCollector(
+        reg,
+        html_fetcher=lambda url: SAMPLE_HTML,
+        pdf_fetcher=failing,
+    )
+    with caplog.at_level(logging.WARNING):
+        result = collector.collect_one(reg.get("1234"))  # type: ignore[arg-type]
+    assert result.extraction_status == "pdf_failed"
+    assert result.error == "404"
+
+
+def test_collect_for_codes_skips_unknown(caplog: pytest.LogCaptureFixture) -> None:
+    reg = _registry(["1234"])
+    collector = IrDocsCollector(
+        reg,
+        html_fetcher=lambda url: SAMPLE_HTML,
+        pdf_fetcher=lambda url: b"x",
+        text_extractor=lambda b: "本文",
+    )
+    with caplog.at_level(logging.WARNING):
+        out = collector.collect_for_codes(["1234", "9999"])
+    assert {r.code for r in out} == {"1234"}
+    assert any("registry missing" in rec.message for rec in caplog.records)
+
+
+def test_upsert_ir_documents() -> None:
+    results = [
+        IrDocsResult(code="1234", pdf_url="https://x.pdf", extraction_status="ok", body_text="本文"),
+        IrDocsResult(code="5678", pdf_url=None, extraction_status="not_found", body_text=None),
+    ]
+    n = upsert_ir_documents(results)
+    assert n == 2
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT code, extraction_status FROM ir_documents ORDER BY code"
+        ).fetchall()
+    assert {r[0] for r in rows} == {"1234", "5678"}
+
+
+def test_collect_10_codes_minimum() -> None:
+    """受入基準: 10銘柄分以上の収集が走り、結果がDBに反映される."""
+    codes = [f"{1000 + i:04d}" for i in range(10)]
+    reg = _registry(codes)
+    collector = IrDocsCollector(
+        reg,
+        html_fetcher=lambda url: SAMPLE_HTML,
+        pdf_fetcher=lambda url: b"x",
+        text_extractor=lambda b: "決算説明本文",
+    )
+    results = collector.collect_for_codes()
+    assert len(results) == 10
+    assert all(r.extraction_status == "ok" for r in results)
+    upsert_ir_documents(results)
+    with get_conn(read_only=True) as conn:
+        n = conn.execute("SELECT COUNT(DISTINCT code) FROM ir_documents").fetchone()
+    assert n is not None and n[0] == 10


### PR DESCRIPTION
## Summary
- 銘柄→IRページURLレジストリ (YAML)
- IRページの HTML から「決算説明」キーワードを含む PDF を抽出 → DL → pypdf でテキスト化
- 注入可能な `html_fetcher` / `pdf_fetcher` / `text_extractor` で完全モック可能
- 失敗ステータス（html/pdf/extract/not_found）をログ＆DB保存
- CLI: `python -m quantmind.data.ir_docs collect --registry path.yaml`

Closes #6

## Test plan
- [x] レジストリ YAML ロード
- [x] 正常系: HTML→PDF抽出→テキスト化→DB保存
- [x] PDF リンク無し時 `not_found`、取得失敗時 `pdf_failed` がログ・結果に残る
- [x] 10銘柄分の収集が正しく行えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)