### PR TITLE
[#8] マクロレジーム判定（Risk On/Off）

### DIFF
--- a/src/quantmind/regime/__init__.py
+++ b/src/quantmind/regime/__init__.py
@@ -1,0 +1,17 @@
+"""マクロレジーム判定（Risk On/Off）."""
+
+from quantmind.regime.detector import (
+    DEFAULT_CONFIG,
+    RegimeConfig,
+    RegimeResult,
+    classify_regime,
+    save_regime,
+)
+
+__all__ = [
+    "DEFAULT_CONFIG",
+    "RegimeConfig",
+    "RegimeResult",
+    "classify_regime",
+    "save_regime",
+]

--- a/src/quantmind/regime/config.yaml
+++ b/src/quantmind/regime/config.yaml
@@ -1,0 +1,5 @@
+vix_high: 25.0
+vix_extreme: 35.0
+n225_below_ma25_pct: -3.0
+usdjpy_change_5d_pct: -3.0
+risk_off_score_threshold: 0.5

--- a/src/quantmind/regime/detector.py
+++ b/src/quantmind/regime/detector.py
@@ -1,0 +1,111 @@
+"""VIX / 日経平均25日線 / 円ドル から Risk On/Off を判定."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from quantmind.storage import get_conn
+
+
+@dataclass(frozen=True)
+class RegimeConfig:
+    vix_high: float = 25.0          # この値超で risk_off 寄り
+    vix_extreme: float = 35.0       # 暴落シグナル
+    n225_below_ma25_pct: float = -3.0  # 25日線比 -3% 以下を弱気とする
+    usdjpy_change_5d_pct: float = -3.0  # 5日変化が -3% 以下（円急騰）= Risk Off
+    risk_off_score_threshold: float = 0.5  # 0..1。これ以上で risk_off
+
+
+DEFAULT_CONFIG = RegimeConfig()
+
+
+@dataclass
+class RegimeResult:
+    as_of: date
+    regime: str  # risk_on / risk_off / neutral
+    score: float  # 0..1（高いほど risk_off 寄り）
+    components: dict[str, Any] = field(default_factory=dict)
+
+
+def _safe_pct_change(current: float, base: float) -> float:
+    if base == 0:
+        return 0.0
+    return (current - base) / base * 100.0
+
+
+def classify_regime(
+    *,
+    vix: float | None,
+    n225_close: float | None,
+    n225_ma25: float | None,
+    usdjpy: float | None,
+    usdjpy_5d_ago: float | None,
+    as_of: date,
+    config: RegimeConfig = DEFAULT_CONFIG,
+) -> RegimeResult:
+    """各指標から合成スコアを計算してレジーム判定."""
+    components: dict[str, Any] = {}
+    score = 0.0
+    n_components = 0
+
+    if vix is not None:
+        components["vix"] = vix
+        if vix >= config.vix_extreme:
+            score += 1.0
+        elif vix >= config.vix_high:
+            score += 0.6
+        else:
+            score += 0.0
+        n_components += 1
+
+    if n225_close is not None and n225_ma25 is not None:
+        diff = _safe_pct_change(n225_close, n225_ma25)
+        components["n225_vs_ma25_pct"] = diff
+        if diff <= config.n225_below_ma25_pct:
+            score += 0.8
+        elif diff < 0:
+            score += 0.3
+        else:
+            score += 0.0
+        n_components += 1
+
+    if usdjpy is not None and usdjpy_5d_ago is not None:
+        change = _safe_pct_change(usdjpy, usdjpy_5d_ago)
+        components["usdjpy_change_5d_pct"] = change
+        if change <= config.usdjpy_change_5d_pct:
+            score += 0.6
+        elif change < 0:
+            score += 0.2
+        else:
+            score += 0.0
+        n_components += 1
+
+    normalized = score / n_components if n_components > 0 else 0.0
+    if normalized >= config.risk_off_score_threshold:
+        regime = "risk_off"
+    elif normalized < 0.2:
+        regime = "risk_on"
+    else:
+        regime = "neutral"
+    return RegimeResult(as_of=as_of, regime=regime, score=normalized, components=components)
+
+
+def load_config(path: Path) -> RegimeConfig:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return RegimeConfig(**raw)
+
+
+def save_regime(result: RegimeResult) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO macro_regime_daily(date, regime, score, components) "
+            "VALUES (?, ?, ?, ?) ON CONFLICT(date) DO UPDATE SET "
+            "regime=excluded.regime, score=excluded.score, components=excluded.components",
+            [result.as_of, result.regime, result.score, json.dumps(result.components)],
+        )

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1,0 +1,105 @@
+"""マクロレジーム判定テスト."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.regime import classify_regime, save_regime
+from quantmind.regime.detector import DEFAULT_CONFIG, load_config
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def test_calm_market_is_risk_on() -> None:
+    result = classify_regime(
+        vix=14.0,
+        n225_close=39000.0,
+        n225_ma25=38500.0,  # +1.3%
+        usdjpy=150.0,
+        usdjpy_5d_ago=149.5,  # +0.3%
+        as_of=date(2026, 4, 30),
+    )
+    assert result.regime == "risk_on"
+    assert result.score < 0.2
+
+
+def test_corona_shock_is_risk_off() -> None:
+    """2020-03 コロナショック相当: VIX 80, 日経 -20%, 円急騰."""
+    result = classify_regime(
+        vix=80.0,
+        n225_close=17000.0,
+        n225_ma25=21000.0,  # -19%
+        usdjpy=102.0,
+        usdjpy_5d_ago=110.0,  # -7.3%
+        as_of=date(2020, 3, 16),
+    )
+    assert result.regime == "risk_off"
+    assert result.score >= 0.5
+    assert "vix" in result.components
+    assert result.components["vix"] == 80.0
+
+
+def test_neutral_zone() -> None:
+    result = classify_regime(
+        vix=27.0,  # 25..35 → 0.6
+        n225_close=38000.0,
+        n225_ma25=38500.0,  # -1.3% → 0.3
+        usdjpy=150.0,
+        usdjpy_5d_ago=151.0,  # -0.66% → 0.2
+        as_of=date(2026, 4, 30),
+    )
+    # 平均 = (0.6+0.3+0.2)/3 ≒ 0.366 → neutral
+    assert result.regime == "neutral"
+    assert 0.2 <= result.score < 0.5
+
+
+def test_partial_data_still_works() -> None:
+    result = classify_regime(
+        vix=18.0,
+        n225_close=None,
+        n225_ma25=None,
+        usdjpy=None,
+        usdjpy_5d_ago=None,
+        as_of=date(2026, 4, 30),
+    )
+    assert result.regime == "risk_on"  # VIX 18 → score 0
+
+
+def test_config_yaml_load(tmp_path: Path) -> None:
+    p = tmp_path / "c.yaml"
+    p.write_text(
+        "vix_high: 20.0\nvix_extreme: 30.0\nrisk_off_score_threshold: 0.4\n", encoding="utf-8"
+    )
+    cfg = load_config(p)
+    assert cfg.vix_high == 20.0
+    assert cfg.vix_extreme == 30.0
+    assert cfg.risk_off_score_threshold == 0.4
+    # 未指定はデフォルト
+    assert cfg.n225_below_ma25_pct == DEFAULT_CONFIG.n225_below_ma25_pct
+
+
+def test_save_regime_roundtrip() -> None:
+    result = classify_regime(
+        vix=14.0,
+        n225_close=39000.0,
+        n225_ma25=38500.0,
+        usdjpy=150.0,
+        usdjpy_5d_ago=149.5,
+        as_of=date(2026, 4, 30),
+    )
+    save_regime(result)
+    save_regime(result)  # 冪等
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT regime FROM macro_regime_daily WHERE date='2026-04-30'"
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "risk_on"


### PR DESCRIPTION
## Summary
- VIX水準・日経 vs 25日線・USDJPY 5日変化を合成して `risk_on` / `neutral` / `risk_off` を返す
- `RegimeConfig` を YAML 外部化（`src/quantmind/regime/config.yaml`）
- `classify_regime()` は dataclass `RegimeResult`（score/components）を返す
- `macro_regime_daily` テーブルに UPSERT

Closes #8

## Test plan
- [x] 平穏な市況 → `risk_on`
- [x] コロナショック相当（VIX 80, 日経 -19%, 円急騰）→ `risk_off`
- [x] 中間ゾーンが neutral
- [x] 部分データのみでも動作
- [x] YAML config ロード、save 冪等性

🤖 Generated with [Claude Code](https://claude.com/claude-code)