### PR TITLE
[#7] ユニバース構築（小型株フィルタ）

### DIFF
--- a/src/quantmind/universe/__init__.py
+++ b/src/quantmind/universe/__init__.py
@@ -1,0 +1,15 @@
+"""ユニバース構築（小型株フィルタ）."""
+
+from quantmind.universe.builder import (
+    UniverseConfig,
+    UniverseRow,
+    build_universe,
+    save_universe_snapshot,
+)
+
+__all__ = [
+    "UniverseConfig",
+    "UniverseRow",
+    "build_universe",
+    "save_universe_snapshot",
+]

--- a/src/quantmind/universe/__main__.py
+++ b/src/quantmind/universe/__main__.py
@@ -1,0 +1,39 @@
+"""ユニバース構築 CLI."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from quantmind.universe.builder import (
+    UniverseConfig,
+    build_universe,
+    save_universe_snapshot,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.universe")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    b = sub.add_parser("build", help="ユニバース構築・保存")
+    b.add_argument("--date", required=True)
+    b.add_argument("--mcap-cap", type=int, default=50_000_000_000)
+    b.add_argument("--price-max", type=float, default=670.0)
+    b.add_argument("--no-price-filter", action="store_true")
+    b.add_argument("--exclude-market", nargs="*", default=[])
+
+    args = parser.parse_args(argv)
+    cfg = UniverseConfig(
+        market_cap_cap_jpy=args.mcap_cap,
+        price_max_jpy=None if args.no_price_filter else args.price_max,
+        excluded_markets=tuple(args.exclude_market),
+    )
+    rows = build_universe(date.fromisoformat(args.date), config=cfg)
+    n = save_universe_snapshot(date.fromisoformat(args.date), rows)
+    included = sum(1 for r in rows if r.included)
+    print(f"saved {n} rows; included={included}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/universe/builder.py
+++ b/src/quantmind/universe/builder.py
@@ -1,0 +1,104 @@
+"""小型株ユニバース構築."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date
+
+from quantmind.storage import get_conn
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UniverseConfig:
+    market_cap_cap_jpy: int = 50_000_000_000  # 500億円
+    price_max_jpy: float | None = 670.0  # 単元株×20万円÷5銘柄想定
+    excluded_markets: tuple[str, ...] = ()
+    excluded_codes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class UniverseRow:
+    code: str
+    market_cap_jpy: int | None
+    last_close: float | None
+    included: bool
+    reason: str
+
+
+def _last_close(conn, code: str, as_of: date) -> float | None:
+    row = conn.execute(
+        "SELECT close FROM price_daily WHERE code=? AND date<=? ORDER BY date DESC LIMIT 1",
+        [code, as_of],
+    ).fetchone()
+    return None if row is None else float(row[0])
+
+
+def build_universe(
+    as_of: date,
+    *,
+    config: UniverseConfig | None = None,
+) -> list[UniverseRow]:
+    """``stocks_master`` × 直近 ``price_daily`` から条件適合銘柄を抽出する.
+
+    上場廃止／監理銘柄の除外は ``excluded_codes`` で行う（外部からリスト供給）。
+    """
+    cfg = config or UniverseConfig()
+    out: list[UniverseRow] = []
+    with get_conn(read_only=True) as conn:
+        rows: Iterable[tuple] = conn.execute(
+            "SELECT code, market, market_cap_jpy FROM stocks_master"
+        ).fetchall()
+
+        for code, market, mcap in rows:
+            included = True
+            reason_parts: list[str] = []
+
+            if code in cfg.excluded_codes:
+                included = False
+                reason_parts.append("excluded_code")
+
+            if market in cfg.excluded_markets:
+                included = False
+                reason_parts.append(f"excluded_market:{market}")
+
+            if mcap is not None and mcap > cfg.market_cap_cap_jpy:
+                included = False
+                reason_parts.append("mcap_over")
+
+            close = _last_close(conn, code, as_of)
+            if cfg.price_max_jpy is not None and close is not None and close > cfg.price_max_jpy:
+                included = False
+                reason_parts.append("price_over")
+
+            reason = ",".join(reason_parts) if reason_parts else "ok"
+            out.append(
+                UniverseRow(
+                    code=code,
+                    market_cap_jpy=mcap,
+                    last_close=close,
+                    included=included,
+                    reason=reason,
+                )
+            )
+    n_included = sum(1 for r in out if r.included)
+    log.info("universe %s: total=%d included=%d", as_of, len(out), n_included)
+    return out
+
+
+def save_universe_snapshot(as_of: date, rows: list[UniverseRow]) -> int:
+    n = 0
+    with get_conn() as conn:
+        # 同日既存を削除して再投入
+        conn.execute("DELETE FROM universe_snapshots WHERE date=?", [as_of])
+        for r in rows:
+            conn.execute(
+                "INSERT INTO universe_snapshots(date, code, market_cap_jpy, last_close, included, reason) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                [as_of, r.code, r.market_cap_jpy, r.last_close, r.included, r.reason],
+            )
+            n += 1
+    return n

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -1,0 +1,97 @@
+"""ユニバース構築テスト."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.storage import get_conn, init_db
+from quantmind.universe import (
+    UniverseConfig,
+    build_universe,
+    save_universe_snapshot,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+    # 銘柄マスタ + 直近終値を投入
+    with get_conn() as conn:
+        rows = [
+            # (code, name, market, mcap_jpy)
+            ("1000", "Small A", "growth", 30_000_000_000),  # 300億, 価格500 → ok
+            ("2000", "Small B", "standard", 49_000_000_000),  # 490億, 価格700 → 価格超
+            ("3000", "Mid", "prime", 80_000_000_000),         # 800億 → mcap超
+            ("4000", "Cheap Big", "prime", 200_000_000_000),  # 2000億 → mcap超
+            ("5000", "Tiny growth", "growth", 5_000_000_000),  # 50億, 価格200 → ok
+        ]
+        for code, name, market, mcap in rows:
+            conn.execute(
+                "INSERT INTO stocks_master(code, name, market, market_cap_jpy) VALUES (?, ?, ?, ?)",
+                [code, name, market, mcap],
+            )
+        prices = [("1000", 500.0), ("2000", 700.0), ("3000", 1500.0), ("4000", 800.0), ("5000", 200.0)]
+        for code, close in prices:
+            conn.execute(
+                "INSERT INTO price_daily(code, date, open, high, low, close, volume, source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, 'fake')",
+                [code, date(2026, 4, 30), close - 5, close + 5, close - 10, close, 100000],
+            )
+
+
+def test_default_config_filters_correctly() -> None:
+    rows = build_universe(date(2026, 4, 30))
+    by_code = {r.code: r for r in rows}
+    assert by_code["1000"].included is True
+    assert by_code["2000"].included is False  # 価格700>670
+    assert by_code["3000"].included is False  # mcap 800億
+    assert by_code["4000"].included is False  # mcap 2000億
+    assert by_code["5000"].included is True
+
+
+def test_no_price_filter_lets_price_pass() -> None:
+    rows = build_universe(
+        date(2026, 4, 30),
+        config=UniverseConfig(market_cap_cap_jpy=50_000_000_000, price_max_jpy=None),
+    )
+    by_code = {r.code: r for r in rows}
+    assert by_code["2000"].included is True  # 価格制約なし、490億で通る
+
+
+def test_excluded_market_filters_out_prime() -> None:
+    rows = build_universe(
+        date(2026, 4, 30),
+        config=UniverseConfig(
+            market_cap_cap_jpy=300_000_000_000,
+            price_max_jpy=None,
+            excluded_markets=("prime",),
+        ),
+    )
+    by_code = {r.code: r for r in rows}
+    assert by_code["3000"].included is False
+    assert "excluded_market:prime" in by_code["3000"].reason
+
+
+def test_save_universe_snapshot_replaces_same_day() -> None:
+    rows = build_universe(date(2026, 4, 30))
+    n1 = save_universe_snapshot(date(2026, 4, 30), rows)
+    n2 = save_universe_snapshot(date(2026, 4, 30), rows)
+    assert n1 == n2
+    with get_conn(read_only=True) as conn:
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM universe_snapshots WHERE date='2026-04-30'"
+        ).fetchone()
+    assert cnt is not None
+    assert cnt[0] == n1
+
+
+def test_universe_size_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        build_universe(date(2026, 4, 30))
+    assert any("universe" in rec.message and "included" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- `UniverseConfig` で時価総額上限（既定 500億円）、株価上限（既定 670円）、除外市場、除外コードを切替
- `stocks_master` × 直近 `price_daily` で `build_universe(as_of)` 実行
- 各銘柄に `included` / `reason` を付与
- `universe_snapshots` テーブルに UPSERT（同日は差し替え）
- CLI: `python -m quantmind.universe build --date YYYY-MM-DD --mcap-cap N --price-max P [--no-price-filter]`

Closes #7

## Test plan
- [x] 既定パラメータでサイズ・価格条件でフィルタが動く
- [x] `--no-price-filter` 相当で価格制約が解除
- [x] 除外市場フィルタが reason に乗る
- [x] スナップショット保存の冪等性
- [x] サイズログが出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)