### PR TITLE
[#9] ルールベース事前スクリーニング（LLM投入前Top N選定）

### DIFF
--- a/src/quantmind/screening/__init__.py
+++ b/src/quantmind/screening/__init__.py
@@ -1,0 +1,15 @@
+"""ルールベース事前スクリーニング."""
+
+from quantmind.screening.rule_screener import (
+    DEFAULT_RULE_WEIGHTS,
+    ScreeningResult,
+    save_screening,
+    screen,
+)
+
+__all__ = [
+    "DEFAULT_RULE_WEIGHTS",
+    "ScreeningResult",
+    "save_screening",
+    "screen",
+]

--- a/src/quantmind/screening/__main__.py
+++ b/src/quantmind/screening/__main__.py
@@ -1,0 +1,27 @@
+"""スクリーニング CLI."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from quantmind.screening.rule_screener import save_screening, screen
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.screening")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    r = sub.add_parser("run", help="Top N スクリーニング")
+    r.add_argument("--date", required=True)
+    r.add_argument("--top", type=int, default=10)
+
+    args = parser.parse_args(argv)
+    results = screen(date.fromisoformat(args.date), top_n=args.top)
+    save_screening(date.fromisoformat(args.date), results)
+    for rank, item in enumerate(results, start=1):
+        print(f"{rank:>2} {item.code} score={item.score:.2f} rules={item.rules_hit}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/screening/rule_screener.py
+++ b/src/quantmind/screening/rule_screener.py
@@ -1,0 +1,146 @@
+"""ルールベース事前スクリーニング.
+
+ユニバースから Top N 銘柄を抽出し、各ルールのヒット理由を保持する。
+LLM 投入対象を絞るための前段。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+import pandas as pd
+
+from quantmind.storage import get_conn
+
+DEFAULT_RULE_WEIGHTS: dict[str, float] = {
+    "volume_spike": 1.0,    # 出来高急増
+    "tdnet_today": 0.8,     # 当日TDnet開示あり
+    "ma25_deviation": 0.7,  # 25日線乖離
+    "post_earnings": 0.6,   # 直近決算後の価格反応
+}
+
+VOLUME_SPIKE_RATIO = 2.0  # 当日出来高 / 20日平均 >= 2.0
+MA25_DEVIATION_PCT = 5.0  # |close/MA25-1| >= 5%
+POST_EARNINGS_DAYS = 5     # 直近5営業日内に earnings 開示
+EARNINGS_PRICE_REACTION_PCT = 5.0  # 反応 ±5%
+
+
+@dataclass(frozen=True)
+class ScreeningResult:
+    code: str
+    score: float
+    rules_hit: list[str]
+
+
+def _price_history(conn, code: str, end: date, lookback: int = 30) -> pd.DataFrame:
+    rows = conn.execute(
+        "SELECT date, close, volume FROM price_daily WHERE code=? AND date<=? "
+        "ORDER BY date DESC LIMIT ?",
+        [code, end, lookback],
+    ).fetchall()
+    if not rows:
+        return pd.DataFrame(columns=["date", "close", "volume"])
+    df = pd.DataFrame(rows, columns=["date", "close", "volume"])
+    return df.sort_values("date").reset_index(drop=True)
+
+
+def _has_volume_spike(prices: pd.DataFrame) -> bool:
+    if len(prices) < 21:
+        return False
+    avg20 = prices["volume"].iloc[-21:-1].mean()
+    if avg20 <= 0:
+        return False
+    return bool(prices["volume"].iloc[-1] >= avg20 * VOLUME_SPIKE_RATIO)
+
+
+def _has_tdnet_today(conn, code: str, as_of: date) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM disclosures WHERE code=? AND CAST(disclosed_at AS DATE)=? LIMIT 1",
+        [code, as_of],
+    ).fetchone()
+    return row is not None
+
+
+def _has_ma25_deviation(prices: pd.DataFrame) -> bool:
+    if len(prices) < 25:
+        return False
+    ma25 = prices["close"].iloc[-25:].mean()
+    if ma25 == 0:
+        return False
+    deviation = abs(prices["close"].iloc[-1] / ma25 - 1.0) * 100.0
+    return bool(deviation >= MA25_DEVIATION_PCT)
+
+
+def _has_post_earnings_reaction(conn, code: str, prices: pd.DataFrame, as_of: date) -> bool:
+    if len(prices) < 2:
+        return False
+    earliest = as_of - timedelta(days=POST_EARNINGS_DAYS)
+    row = conn.execute(
+        "SELECT 1 FROM disclosures WHERE code=? AND doc_type='earnings' "
+        "AND CAST(disclosed_at AS DATE) BETWEEN ? AND ? LIMIT 1",
+        [code, earliest, as_of],
+    ).fetchone()
+    if row is None:
+        return False
+    # 直近5営業日内で価格±5%反応
+    closes = prices["close"].tail(POST_EARNINGS_DAYS + 1)
+    if len(closes) < 2:
+        return False
+    change = abs(closes.iloc[-1] / closes.iloc[0] - 1.0) * 100.0
+    return bool(change >= EARNINGS_PRICE_REACTION_PCT)
+
+
+def screen(
+    as_of: date,
+    *,
+    top_n: int = 10,
+    weights: dict[str, float] | None = None,
+) -> list[ScreeningResult]:
+    """対象日のユニバース included=True からスコアリング Top N 抽出."""
+    w = {**DEFAULT_RULE_WEIGHTS, **(weights or {})}
+    out: list[ScreeningResult] = []
+    with get_conn(read_only=True) as conn:
+        codes = [
+            row[0]
+            for row in conn.execute(
+                "SELECT code FROM universe_snapshots WHERE date=? AND included=TRUE",
+                [as_of],
+            ).fetchall()
+        ]
+        for code in codes:
+            prices = _price_history(conn, code, as_of, lookback=30)
+            rules_hit: list[str] = []
+            score = 0.0
+            if _has_volume_spike(prices):
+                rules_hit.append("volume_spike")
+                score += w["volume_spike"]
+            if _has_tdnet_today(conn, code, as_of):
+                rules_hit.append("tdnet_today")
+                score += w["tdnet_today"]
+            if _has_ma25_deviation(prices):
+                rules_hit.append("ma25_deviation")
+                score += w["ma25_deviation"]
+            if _has_post_earnings_reaction(conn, code, prices, as_of):
+                rules_hit.append("post_earnings")
+                score += w["post_earnings"]
+            if score > 0:
+                out.append(ScreeningResult(code=code, score=score, rules_hit=rules_hit))
+
+    out.sort(key=lambda r: r.score, reverse=True)
+    return out[:top_n]
+
+
+def save_screening(as_of: date, results: list[ScreeningResult]) -> int:
+    n = 0
+    with get_conn() as conn:
+        conn.execute("DELETE FROM screening_daily WHERE date=?", [as_of])
+        for rank, r in enumerate(results, start=1):
+            conn.execute(
+                "INSERT INTO screening_daily(date, code, score, rules_hit, rank) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [as_of, r.code, r.score, json.dumps(r.rules_hit, ensure_ascii=False), rank],
+            )
+            n += 1
+    return n

--- a/tests/test_screening.py
+++ b/tests/test_screening.py
@@ -1,0 +1,134 @@
+"""ルールベース事前スクリーニングテスト."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from quantmind.screening import save_screening, screen
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def _seed_universe(codes: list[str], as_of: date) -> None:
+    with get_conn() as conn:
+        for c in codes:
+            conn.execute(
+                "INSERT INTO universe_snapshots(date, code, market_cap_jpy, last_close, included, reason) "
+                "VALUES (?, ?, ?, ?, ?, 'ok')",
+                [as_of, c, 10_000_000_000, 500.0, True],
+            )
+
+
+def _seed_prices(code: str, end: date, closes: list[float], volumes: list[int]) -> None:
+    """end から遡って n 日分を投入."""
+    with get_conn() as conn:
+        for i, (close, vol) in enumerate(zip(closes, volumes, strict=True)):
+            d = end - timedelta(days=len(closes) - 1 - i)
+            conn.execute(
+                "INSERT INTO price_daily(code, date, open, high, low, close, volume, source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, 'fake') "
+                "ON CONFLICT(code, date) DO UPDATE SET close=excluded.close, volume=excluded.volume",
+                [code, d, close, close + 1, close - 1, close, vol],
+            )
+
+
+def test_screen_picks_volume_spike() -> None:
+    as_of = date(2026, 4, 30)
+    _seed_universe(["1000", "2000"], as_of)
+    # code 1000: 平常出来高 10000、当日 30000 で急増
+    _seed_prices(
+        "1000",
+        as_of,
+        closes=[500.0] * 25,
+        volumes=[10000] * 24 + [30000],
+    )
+    # code 2000: 静か（ヒットしない）
+    _seed_prices(
+        "2000",
+        as_of,
+        closes=[500.0] * 25,
+        volumes=[10000] * 25,
+    )
+    res = screen(as_of, top_n=10)
+    codes = [r.code for r in res]
+    assert "1000" in codes
+    assert "2000" not in codes
+    r1 = next(r for r in res if r.code == "1000")
+    assert "volume_spike" in r1.rules_hit
+
+
+def test_screen_picks_tdnet_today() -> None:
+    as_of = date(2026, 4, 30)
+    _seed_universe(["3000"], as_of)
+    _seed_prices("3000", as_of, closes=[500.0] * 25, volumes=[10000] * 25)
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO disclosures(id, code, source, doc_type, title, disclosed_at, url) "
+            "VALUES ('d1', '3000', 'tdnet', 'forecast_revision', 'X', ?, NULL)",
+            [datetime(2026, 4, 30, 15, 0)],
+        )
+    res = screen(as_of)
+    assert any(r.code == "3000" and "tdnet_today" in r.rules_hit for r in res)
+
+
+def test_screen_picks_ma25_deviation() -> None:
+    as_of = date(2026, 4, 30)
+    _seed_universe(["4000"], as_of)
+    closes = [500.0] * 24 + [600.0]  # 直近 +20% 乖離
+    _seed_prices("4000", as_of, closes=closes, volumes=[10000] * 25)
+    res = screen(as_of)
+    assert any(r.code == "4000" and "ma25_deviation" in r.rules_hit for r in res)
+
+
+def test_screen_picks_post_earnings_reaction() -> None:
+    as_of = date(2026, 4, 30)
+    _seed_universe(["5000"], as_of)
+    closes = [500.0] * 20 + [500.0, 510.0, 530.0, 550.0, 580.0]  # 直近5日で +16%
+    _seed_prices("5000", as_of, closes=closes, volumes=[10000] * 25)
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO disclosures(id, code, source, doc_type, title, disclosed_at, url) "
+            "VALUES ('e1', '5000', 'tdnet', 'earnings', 'short shinpo', ?, NULL)",
+            [datetime(2026, 4, 28, 15, 0)],
+        )
+    res = screen(as_of)
+    assert any(r.code == "5000" and "post_earnings" in r.rules_hit for r in res)
+
+
+def test_top_n_truncates() -> None:
+    as_of = date(2026, 4, 30)
+    codes = [f"{1000 + i:04d}" for i in range(15)]
+    _seed_universe(codes, as_of)
+    for i, c in enumerate(codes):
+        # i 大きいほどボラ大きく → スコア高
+        spike = 30000 + i * 1000
+        _seed_prices(c, as_of, closes=[500.0] * 25, volumes=[10000] * 24 + [spike])
+    res = screen(as_of, top_n=5)
+    assert len(res) == 5
+    # スコア降順
+    assert res == sorted(res, key=lambda r: r.score, reverse=True)
+
+
+def test_save_screening_persists_rules_hit() -> None:
+    as_of = date(2026, 4, 30)
+    _seed_universe(["1000"], as_of)
+    _seed_prices("1000", as_of, closes=[500.0] * 25, volumes=[10000] * 24 + [30000])
+    res = screen(as_of)
+    save_screening(as_of, res)
+    save_screening(as_of, res)  # 冪等
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT code, rules_hit FROM screening_daily WHERE date=?", [as_of]
+        ).fetchall()
+    assert len(rows) == 1
+    parsed = json.loads(rows[0][1])
+    assert "volume_spike" in parsed


### PR DESCRIPTION
## Summary
- 4つの初期ルール: `volume_spike` / `tdnet_today` / `ma25_deviation` / `post_earnings`
- 各ルールに重みを設定（`DEFAULT_RULE_WEIGHTS`）して合成スコアで Top N 抽出
- `ScreeningResult.rules_hit` に発火ルールを記録（後段の LLM プロンプトで参照）
- `screening_daily` に rank・score・rules_hit JSON を永続化
- 戦略ロジックは本モジュールに集約（バックテスト対象）

Closes #9

## Test plan
- [x] 出来高急増 / 当日 TDnet / 25日線乖離 / 決算後反応 の各ルールが個別にヒット
- [x] Top N 切り詰めとスコア降順
- [x] 保存の冪等性（同日上書き）

🤖 Generated with [Claude Code](https://claude.com/claude-code)