### PR TITLE
[#12] 反証シナリオ生成・永続化

### DIFF
--- a/src/quantmind/falsifiability/__init__.py
+++ b/src/quantmind/falsifiability/__init__.py
@@ -1,0 +1,17 @@
+"""反証シナリオの生成と監視."""
+
+from quantmind.falsifiability.generator import (
+    FalsifiabilityScenario,
+    QualitativeTrigger,
+    QuantitativeTrigger,
+    generate_scenario,
+    save_scenario,
+)
+
+__all__ = [
+    "FalsifiabilityScenario",
+    "QualitativeTrigger",
+    "QuantitativeTrigger",
+    "generate_scenario",
+    "save_scenario",
+]

--- a/src/quantmind/falsifiability/generator.py
+++ b/src/quantmind/falsifiability/generator.py
@@ -1,0 +1,177 @@
+"""反証シナリオの生成・保存."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from quantmind.llm.debate import DebateResult
+from quantmind.llm.runner import LLMRunner, log_decision
+from quantmind.storage import get_conn
+
+PROMPT_PATH = Path(__file__).parent / "prompt.txt"
+
+VALID_OPERATORS = {"<=", ">=", "<", ">", "==", "!="}
+ALLOWED_METRICS = {
+    "price",
+    "close",
+    "volume",
+    "volume_ratio_20d",
+    "rsi",
+    "drawdown_pct",
+    "ma25_deviation_pct",
+    "net_income_yoy",
+    "revenue_yoy",
+}
+
+
+@dataclass
+class QuantitativeTrigger:
+    metric: str
+    operator: str
+    threshold: float
+    window: str
+
+    def validate(self) -> None:
+        if self.operator not in VALID_OPERATORS:
+            raise ValueError(f"invalid operator: {self.operator}")
+        # metric は LLM 自由入力を許容するが、自動評価可能なのは ALLOWED_METRICS
+        if not isinstance(self.threshold, (int, float)):
+            raise ValueError("threshold must be numeric")
+
+
+@dataclass
+class QualitativeTrigger:
+    description: str
+    hints: str = ""
+
+
+@dataclass
+class FalsifiabilityScenario:
+    id: str
+    code: str
+    narrative: str
+    quantitative_triggers: list[QuantitativeTrigger] = field(default_factory=list)
+    qualitative_triggers: list[QualitativeTrigger] = field(default_factory=list)
+    status: str = "active"
+    created_at: datetime = field(default_factory=datetime.now)
+
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _parse_json(text: str) -> dict[str, Any]:
+    m = _JSON_RE.search(text)
+    if not m:
+        raise ValueError("no JSON object in LLM output")
+    return json.loads(m.group(0))
+
+
+def parse_scenario(code: str, llm_text: str, *, scenario_id: str | None = None) -> FalsifiabilityScenario:
+    raw = _parse_json(llm_text)
+    quants_raw = raw.get("quantitative_triggers", []) or []
+    quals_raw = raw.get("qualitative_triggers", []) or []
+    quants = []
+    for q in quants_raw:
+        threshold = q.get("threshold")
+        if isinstance(threshold, str):
+            try:
+                threshold = float(threshold)
+            except ValueError as exc:  # 受入基準: 機械判定可能な形式
+                raise ValueError(f"non-numeric threshold: {threshold}") from exc
+        trig = QuantitativeTrigger(
+            metric=str(q.get("metric", "")).strip(),
+            operator=str(q.get("operator", "")).strip(),
+            threshold=float(threshold or 0.0),
+            window=str(q.get("window", "")).strip(),
+        )
+        trig.validate()
+        quants.append(trig)
+    quals = [
+        QualitativeTrigger(
+            description=str(q.get("description", "")).strip(),
+            hints=str(q.get("hints", "")).strip(),
+        )
+        for q in quals_raw
+    ]
+
+    if len(quants) < 2:
+        raise ValueError(f"need at least 2 quantitative triggers, got {len(quants)}")
+    if len(quals) < 1:
+        raise ValueError(f"need at least 1 qualitative trigger, got {len(quals)}")
+
+    return FalsifiabilityScenario(
+        id=scenario_id or str(uuid.uuid4()),
+        code=code,
+        narrative=str(raw.get("narrative", "")).strip(),
+        quantitative_triggers=quants,
+        qualitative_triggers=quals,
+    )
+
+
+def generate_scenario(
+    runner: LLMRunner,
+    debate: DebateResult,
+    *,
+    name: str = "",
+    persist: bool = True,
+) -> FalsifiabilityScenario:
+    """ディベート結果を入力に反証シナリオを生成."""
+    template = PROMPT_PATH.read_text(encoding="utf-8")
+    prompt = template.format(
+        code=debate.code,
+        name=name,
+        bull_text=debate.bull_text,
+        bear_text=debate.bear_text,
+        judge_summary=debate.summary,
+    )
+    response = runner.run(
+        system_prompt="You generate falsifiable triggers. Output JSON only.",
+        user_prompt=prompt,
+    )
+    if persist:
+        log_decision(
+            code=debate.code,
+            role="falsifiability_gen",
+            response=response,
+            prompt=prompt,
+        )
+    scenario = parse_scenario(debate.code, response.text)
+    if persist:
+        save_scenario(scenario)
+    return scenario
+
+
+def save_scenario(scenario: FalsifiabilityScenario) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO falsifiability_scenarios(id, code, created_at, narrative, "
+            "quantitative_triggers, qualitative_triggers, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "narrative=excluded.narrative, quantitative_triggers=excluded.quantitative_triggers, "
+            "qualitative_triggers=excluded.qualitative_triggers, status=excluded.status",
+            [
+                scenario.id,
+                scenario.code,
+                scenario.created_at,
+                scenario.narrative,
+                json.dumps([asdict(q) for q in scenario.quantitative_triggers], ensure_ascii=False),
+                json.dumps([asdict(q) for q in scenario.qualitative_triggers], ensure_ascii=False),
+                scenario.status,
+            ],
+        )
+
+
+def update_status(scenario_id: str, status: str, *, triggered_at: datetime | None = None) -> None:
+    """状態遷移: active → triggered → resolved."""
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE falsifiability_scenarios SET status=?, triggered_at=? WHERE id=?",
+            [status, triggered_at, scenario_id],
+        )

--- a/src/quantmind/falsifiability/prompt.txt
+++ b/src/quantmind/falsifiability/prompt.txt
@@ -1,0 +1,38 @@
+あなたはBull/Bearディベート結果を受け取り、新規エントリー推奨が「崩れるシナリオ」を抽出するアナリストです。
+
+# 銘柄
+{code} {name}
+
+# Bull 論点
+{bull_text}
+
+# Bear 反論
+{bear_text}
+
+# Judge サマリ
+{judge_summary}
+
+# 出力形式（厳守、JSON）
+{{
+  "narrative": "反証シナリオを1〜3文で説明",
+  "quantitative_triggers": [
+    {{
+      "metric": "price | volume | rsi | drawdown_pct | ma25_deviation_pct | net_income_yoy | ...",
+      "operator": "<= | >= | < | >",
+      "threshold": 数値,
+      "window": "1d | 5d | 20d | next_quarter | ..."
+    }}
+    ... 最低2件
+  ],
+  "qualitative_triggers": [
+    {{
+      "description": "数値化困難な事象（例: 競合が類似新製品を発表）",
+      "hints": "確認手がかり（例: 業界ニュース監視、決算説明資料）"
+    }}
+    ... 最低1件
+  ]
+}}
+
+注意:
+- quantitative_triggers は #13 の自動評価で使うため、metric/operator/threshold/window をすべて埋める
+- threshold は数値（文字列にしない）

--- a/tests/test_falsifiability_generator.py
+++ b/tests/test_falsifiability_generator.py
@@ -1,0 +1,147 @@
+"""反証シナリオ生成テスト."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quantmind.falsifiability import generate_scenario, save_scenario
+from quantmind.falsifiability.generator import (
+    FalsifiabilityScenario,
+    parse_scenario,
+    update_status,
+)
+from quantmind.llm.debate import DebateResult
+from quantmind.llm.runner import LLMResponse
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+VALID_OUTPUT = json.dumps(
+    {
+        "narrative": "業績モメンタムが鈍化したり、競合の追随で価格圧力が強まれば崩れる",
+        "quantitative_triggers": [
+            {"metric": "ma25_deviation_pct", "operator": "<", "threshold": -5.0, "window": "5d"},
+            {"metric": "volume_ratio_20d", "operator": "<", "threshold": 0.5, "window": "5d"},
+        ],
+        "qualitative_triggers": [
+            {"description": "競合が類似新製品を発表", "hints": "業界ニュース"}
+        ],
+    },
+    ensure_ascii=False,
+)
+
+
+def _debate(code: str = "1234") -> DebateResult:
+    return DebateResult(
+        code=code,
+        recommendation="buy",
+        confidence=0.7,
+        summary="業績モメンタム評価",
+        bull_text="売上成長加速",
+        bear_text="競合リスク",
+        judge_text="...",
+    )
+
+
+class FakeRunner:
+    name = "fake"
+
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+    def run(self, system_prompt: str, user_prompt: str, timeout: int = 180) -> LLMResponse:
+        return LLMResponse(
+            text=self.output,
+            model=self.name,
+            raw_stdout=self.output,
+            raw_stderr="",
+            duration_sec=0.0,
+        )
+
+
+def test_parse_scenario_minimum_triggers() -> None:
+    scenario = parse_scenario("1234", VALID_OUTPUT)
+    assert len(scenario.quantitative_triggers) >= 2
+    assert len(scenario.qualitative_triggers) >= 1
+    assert scenario.quantitative_triggers[0].operator == "<"
+    assert scenario.quantitative_triggers[0].threshold == -5.0
+
+
+def test_parse_scenario_rejects_short_triggers() -> None:
+    bad = json.dumps(
+        {
+            "narrative": "x",
+            "quantitative_triggers": [
+                {"metric": "price", "operator": "<", "threshold": 100, "window": "1d"}
+            ],
+            "qualitative_triggers": [{"description": "y", "hints": ""}],
+        }
+    )
+    with pytest.raises(ValueError, match="quantitative"):
+        parse_scenario("1234", bad)
+
+
+def test_parse_scenario_rejects_no_qualitative() -> None:
+    bad = json.dumps(
+        {
+            "narrative": "x",
+            "quantitative_triggers": [
+                {"metric": "price", "operator": "<", "threshold": 100, "window": "1d"},
+                {"metric": "volume", "operator": "<", "threshold": 1000, "window": "5d"},
+            ],
+            "qualitative_triggers": [],
+        }
+    )
+    with pytest.raises(ValueError, match="qualitative"):
+        parse_scenario("1234", bad)
+
+
+def test_generate_scenario_persists() -> None:
+    runner = FakeRunner(VALID_OUTPUT)
+    scenario = generate_scenario(runner, _debate(), name="テスト株式")
+    assert isinstance(scenario, FalsifiabilityScenario)
+    with get_conn(read_only=True) as conn:
+        row = conn.execute(
+            "SELECT code, status, quantitative_triggers FROM falsifiability_scenarios WHERE id=?",
+            [scenario.id],
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "1234"
+    assert row[1] == "active"
+    quants = json.loads(row[2])
+    assert len(quants) >= 2
+
+
+def test_save_scenario_idempotent() -> None:
+    scenario = parse_scenario("1234", VALID_OUTPUT)
+    save_scenario(scenario)
+    save_scenario(scenario)
+    with get_conn(read_only=True) as conn:
+        n = conn.execute(
+            "SELECT COUNT(*) FROM falsifiability_scenarios WHERE id=?", [scenario.id]
+        ).fetchone()
+    assert n is not None
+    assert n[0] == 1
+
+
+def test_update_status() -> None:
+    scenario = parse_scenario("1234", VALID_OUTPUT)
+    save_scenario(scenario)
+    from datetime import datetime
+
+    update_status(scenario.id, "triggered", triggered_at=datetime(2026, 5, 1, 9))
+    with get_conn(read_only=True) as conn:
+        row = conn.execute(
+            "SELECT status, triggered_at FROM falsifiability_scenarios WHERE id=?",
+            [scenario.id],
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "triggered"


### PR DESCRIPTION
## Summary
- ディベート結果を入力に LLM へ反証シナリオ生成を指示するプロンプト（外部 .txt）
- `QuantitativeTrigger`(metric/operator/threshold/window) と `QualitativeTrigger`(description/hints)
- 受入基準を強制: **定量2件以上 + 定性1件以上**でなければ ValueError
- `falsifiability_scenarios` テーブルに保存（ON CONFLICT DO UPDATE）
- 状態遷移: `active` → `triggered` → `resolved`
- 機械判定可能なスキーマ（#13 で利用）

Closes #12

## Test plan
- [x] 正常 LLM 出力 → 2量+1質トリガー抽出
- [x] 量1件のみ・質0件は ValueError
- [x] generate_scenario が DB に永続化される
- [x] save_scenario の冪等性
- [x] update_status で状態遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)