### PR TITLE
[#15] PostMortemループ（クローズ時の予想vs結果記録）

### DIFF
--- a/src/quantmind/learning/__init__.py
+++ b/src/quantmind/learning/__init__.py
@@ -1,0 +1,9 @@
+"""学習ループ: PostMortem."""
+
+from quantmind.learning.postmortem import (
+    PostMortem,
+    create_postmortem,
+    failure_pattern_summary,
+)
+
+__all__ = ["PostMortem", "create_postmortem", "failure_pattern_summary"]

--- a/src/quantmind/learning/postmortem.py
+++ b/src/quantmind/learning/postmortem.py
@@ -1,0 +1,143 @@
+"""クローズ後の PostMortem 生成."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from quantmind.llm.runner import LLMRunner, log_decision
+from quantmind.storage import get_conn
+
+PROMPT_PATH = Path(__file__).parent / "prompt.txt"
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+@dataclass
+class PostMortem:
+    id: str
+    position_id: str
+    code: str
+    summary: str
+    what_worked: str
+    what_missed: str
+    improvement: str
+    pattern_tags: list[str]
+
+
+def _safe_parse(text: str) -> dict[str, Any]:
+    m = _JSON_RE.search(text)
+    if not m:
+        return {}
+    try:
+        return json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return {}
+
+
+def _gather_context(position_id: str) -> dict[str, Any]:
+    with get_conn(read_only=True) as conn:
+        pos = conn.execute(
+            "SELECT id, code, entry_price, entry_date, exit_price, exit_date, realized_pnl, scenario_id "
+            "FROM positions WHERE id=?",
+            [position_id],
+        ).fetchone()
+        if pos is None:
+            raise ValueError(f"position not found: {position_id}")
+        scenario_text = ""
+        alerts_text = ""
+        debate_summary = ""
+        scenario_id = pos[7]
+        if scenario_id:
+            row = conn.execute(
+                "SELECT narrative FROM falsifiability_scenarios WHERE id=?", [scenario_id]
+            ).fetchone()
+            scenario_text = (row[0] if row else "") or ""
+            alert_rows = conn.execute(
+                "SELECT triggered_at, trigger_kind, detail FROM alerts WHERE scenario_id=? "
+                "ORDER BY triggered_at",
+                [scenario_id],
+            ).fetchall()
+            alerts_text = "\n".join(f"- {a[0]} [{a[1]}] {a[2]}" for a in alert_rows) or "(なし)"
+        debate_rows = conn.execute(
+            "SELECT output FROM llm_decisions WHERE code=? AND role='judge' ORDER BY created_at DESC LIMIT 1",
+            [pos[1]],
+        ).fetchone()
+        if debate_rows:
+            debate_summary = debate_rows[0]
+    holding_days = None
+    if pos[3] and pos[5]:
+        holding_days = (pos[5] - pos[3]).days
+    return {
+        "code": pos[1],
+        "entry_price": pos[2],
+        "entry_date": pos[3],
+        "exit_price": pos[4],
+        "exit_date": pos[5],
+        "pnl": pos[6],
+        "holding_days": holding_days,
+        "scenario_narrative": scenario_text,
+        "alerts": alerts_text or "(なし)",
+        "debate_summary": debate_summary or "(なし)",
+    }
+
+
+def create_postmortem(runner: LLMRunner, position_id: str) -> PostMortem:
+    """ポジションをクローズした後に呼び出して PostMortem を生成・保存する."""
+    ctx = _gather_context(position_id)
+    template = PROMPT_PATH.read_text(encoding="utf-8")
+    prompt = template.format(**ctx)
+    response = runner.run(
+        system_prompt="You write a postmortem in JSON.",
+        user_prompt=prompt,
+    )
+    log_decision(code=ctx["code"], role="postmortem", response=response, prompt=prompt)
+    parsed = _safe_parse(response.text)
+    pm = PostMortem(
+        id=str(uuid.uuid4()),
+        position_id=position_id,
+        code=str(ctx["code"]),
+        summary=str(parsed.get("summary", "")),
+        what_worked=str(parsed.get("what_worked", "")),
+        what_missed=str(parsed.get("what_missed", "")),
+        improvement=str(parsed.get("improvement", "")),
+        pattern_tags=[str(t) for t in (parsed.get("pattern_tags") or [])],
+    )
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO postmortems(id, position_id, code, closed_at, summary, what_worked, "
+            "what_missed, improvement, pattern_tags) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                pm.id,
+                position_id,
+                pm.code,
+                datetime.now(),
+                pm.summary,
+                pm.what_worked,
+                pm.what_missed,
+                pm.improvement,
+                ",".join(pm.pattern_tags),
+            ],
+        )
+    return pm
+
+
+def failure_pattern_summary(top_n: int = 10) -> list[tuple[str, int]]:
+    """過去 PostMortem のパターンタグ集計（頻度降順）."""
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute("SELECT pattern_tags FROM postmortems").fetchall()
+    counter: dict[str, int] = {}
+    for (raw,) in rows:
+        if not raw:
+            continue
+        for tag in str(raw).split(","):
+            tag = tag.strip()
+            if not tag:
+                continue
+            counter[tag] = counter.get(tag, 0) + 1
+    return sorted(counter.items(), key=lambda kv: kv[1], reverse=True)[:top_n]

--- a/src/quantmind/learning/prompt.txt
+++ b/src/quantmind/learning/prompt.txt
@@ -1,0 +1,28 @@
+あなたはトレード結果のレビュアーです。以下のクローズした保有銘柄について「予想 vs 結果」をレビューし、JSONで返してください。
+
+# 銘柄
+{code}
+
+# エントリー時のディベート要旨
+{debate_summary}
+
+# 反証シナリオ
+{scenario_narrative}
+
+# 保有期間中の反証トリガー発動履歴
+{alerts}
+
+# クローズ実績
+- エントリー: {entry_date} @ {entry_price}
+- クローズ: {exit_date} @ {exit_price}
+- 損益: {pnl}
+- 保有日数: {holding_days}
+
+# 出力形式（厳守、JSON）
+{{
+  "summary": "結論を1〜2文",
+  "what_worked": "うまくいった理由（1〜3文）",
+  "what_missed": "外れた理由（1〜3文）",
+  "improvement": "今後の改善点（1〜3文）",
+  "pattern_tags": ["パターンタグ1", "パターンタグ2"]
+}}

--- a/tests/test_postmortem.py
+++ b/tests/test_postmortem.py
@@ -1,0 +1,71 @@
+"""PostMortem テスト."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.learning import create_postmortem, failure_pattern_summary
+from quantmind.llm.runner import LLMResponse
+from quantmind.portfolio import close_position, open_position
+from quantmind.storage import init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+PM_OUTPUT = json.dumps(
+    {
+        "summary": "ターゲットに到達したが利食い後に下落",
+        "what_worked": "出来高急増のシグナルが正しく機能",
+        "what_missed": "ストップ位置が浅すぎた",
+        "improvement": "ATRベースのストップに変更を検討",
+        "pattern_tags": ["volume_spike_winner", "stop_too_tight"],
+    },
+    ensure_ascii=False,
+)
+
+
+class FakeRunner:
+    name = "fake"
+
+    def run(self, system_prompt: str, user_prompt: str, timeout: int = 180) -> LLMResponse:
+        return LLMResponse(PM_OUTPUT, "fake", PM_OUTPUT, "", 0.0)
+
+
+def test_create_postmortem_persists() -> None:
+    p = open_position("1234", 100, 500.0, entry_date=date(2026, 4, 1))
+    closed = close_position(p.id, 600.0, exit_date=date(2026, 4, 5))
+    pm = create_postmortem(FakeRunner(), closed.id)
+    assert "stop_too_tight" in pm.pattern_tags
+    assert pm.code == "1234"
+
+
+def test_failure_pattern_summary_counts() -> None:
+    # 3件作成
+    for code in ["1234", "5678", "9012"]:
+        p = open_position(code, 100, 500.0, entry_date=date(2026, 4, 1))
+        closed = close_position(p.id, 600.0, exit_date=date(2026, 4, 5))
+        create_postmortem(FakeRunner(), closed.id)
+    counts = dict(failure_pattern_summary())
+    assert counts.get("volume_spike_winner") == 3
+    assert counts.get("stop_too_tight") == 3
+
+
+def test_postmortem_handles_unparsable_output() -> None:
+    p = open_position("1234", 100, 500.0, entry_date=date(2026, 4, 1))
+    closed = close_position(p.id, 600.0, exit_date=date(2026, 4, 5))
+
+    class Bad(FakeRunner):
+        def run(self, system_prompt: str, user_prompt: str, timeout: int = 180) -> LLMResponse:
+            return LLMResponse("not json", "fake", "not json", "", 0.0)
+
+    pm = create_postmortem(Bad(), closed.id)
+    assert pm.summary == ""
+    assert pm.pattern_tags == []


### PR DESCRIPTION
## Summary
- クローズ実績・直近ディベート要旨・反証シナリオ・保有期間中のトリガー履歴を集約してLLMに投入
- 出力 JSON を `PostMortem` dataclass にマッピングし `postmortems` テーブルに保存
- `failure_pattern_summary()` で過去の `pattern_tags` を頻度降順で集計（自分の失敗パターン抽出）

Closes #15

## Test plan
- [x] open → close → create_postmortem で DB 永続化
- [x] 複数 PostMortem 集計で頻度カウントが正しい
- [x] LLM 出力が壊れていてもフォールバックで保存可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)