### PR TITLE
[#18] バックテストエンジン（ルールベース・Sharpe/MaxDD）

### DIFF
--- a/src/quantmind/backtest/__init__.py
+++ b/src/quantmind/backtest/__init__.py
@@ -1,0 +1,20 @@
+"""ルールベース戦略バックテスト."""
+
+from quantmind.backtest.engine import (
+    BacktestConfig,
+    BacktestResult,
+    Trade,
+    run_backtest,
+)
+from quantmind.backtest.metrics import max_drawdown, sharpe_ratio
+from quantmind.backtest.report import generate_report
+
+__all__ = [
+    "BacktestConfig",
+    "BacktestResult",
+    "Trade",
+    "generate_report",
+    "max_drawdown",
+    "run_backtest",
+    "sharpe_ratio",
+]

--- a/src/quantmind/backtest/__main__.py
+++ b/src/quantmind/backtest/__main__.py
@@ -1,0 +1,30 @@
+"""バックテスト CLI."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+
+from quantmind.backtest.engine import run_backtest
+from quantmind.backtest.report import generate_report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="quantmind.backtest")
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    parser.add_argument("--out", default="reports/backtest.html")
+    args = parser.parse_args(argv)
+
+    result = run_backtest(date.fromisoformat(args.start), date.fromisoformat(args.end))
+    print(f"Sharpe: {result.sharpe:.3f}")
+    print(f"MaxDD : {result.max_drawdown:.2%}")
+    print(f"Trades: {result.n_trades}")
+    out = generate_report(result, Path(args.out))
+    print(f"report: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantmind/backtest/engine.py
+++ b/src/quantmind/backtest/engine.py
@@ -1,0 +1,234 @@
+"""ルールベース戦略の日次バックテスト.
+
+LLM 部分は対象外。``screening_daily`` のスコア（または同等の信号）を
+日次に再現してエントリー／クローズを実行する。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import date
+
+import pandas as pd
+
+from quantmind.backtest.metrics import (
+    max_drawdown,
+    profit_factor,
+    sharpe_ratio,
+    win_rate,
+)
+from quantmind.storage import get_conn
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BacktestConfig:
+    initial_cash: float = 200_000.0
+    max_positions: int = 5
+    take_profit_pct: float = 8.0      # +8% で利食い
+    stop_loss_pct: float = -5.0       # -5% で損切り
+    holding_days_max: int = 20         # 最大保有日数
+    commission_pct: float = 0.05       # 0.05% 片道
+    slippage_pct: float = 0.05         # 0.05%
+    score_threshold: float = 1.5       # screening_daily.score >= でエントリー
+
+
+@dataclass
+class Trade:
+    code: str
+    entry_date: date
+    entry_price: float
+    exit_date: date
+    exit_price: float
+    qty: int
+    pnl: float
+    holding_days: int
+    reason: str  # take_profit / stop_loss / time_exit
+
+
+@dataclass
+class BacktestResult:
+    sharpe: float
+    max_drawdown: float
+    win_rate: float
+    profit_factor: float
+    avg_holding_days: float
+    n_trades: int
+    equity_curve: list[tuple[date, float]] = field(default_factory=list)
+    trades: list[Trade] = field(default_factory=list)
+
+
+def _load_dates(conn, start: date, end: date) -> list[date]:
+    rows = conn.execute(
+        "SELECT DISTINCT date FROM price_daily WHERE date BETWEEN ? AND ? ORDER BY date",
+        [start, end],
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _load_signals(conn, start: date, end: date) -> dict[date, list[tuple[str, float]]]:
+    rows = conn.execute(
+        "SELECT date, code, score FROM screening_daily WHERE date BETWEEN ? AND ? ORDER BY date, rank",
+        [start, end],
+    ).fetchall()
+    signals: dict[date, list[tuple[str, float]]] = {}
+    for d, code, score in rows:
+        signals.setdefault(d, []).append((code, float(score)))
+    return signals
+
+
+def _load_prices(conn, start: date, end: date) -> dict[tuple[date, str], float]:
+    rows = conn.execute(
+        "SELECT date, code, close FROM price_daily WHERE date BETWEEN ? AND ?",
+        [start, end],
+    ).fetchall()
+    return {(r[0], r[1]): float(r[2]) for r in rows}
+
+
+def run_backtest(
+    start: date,
+    end: date,
+    *,
+    config: BacktestConfig | None = None,
+    persist: bool = True,
+) -> BacktestResult:
+    cfg = config or BacktestConfig()
+    cash = cfg.initial_cash
+    positions: dict[str, dict] = {}  # code -> {entry_date, entry_price, qty}
+    trades: list[Trade] = []
+    equity_curve: list[tuple[date, float]] = []
+
+    with get_conn(read_only=True) as conn:
+        dates = _load_dates(conn, start, end)
+        signals = _load_signals(conn, start, end)
+        prices = _load_prices(conn, start, end)
+
+    for d in dates:
+        # 1) ポジションのクローズ判定
+        for code in list(positions.keys()):
+            pos = positions[code]
+            close_price = prices.get((d, code))
+            if close_price is None:
+                continue
+            ret_pct = (close_price / pos["entry_price"] - 1) * 100.0
+            holding = (d - pos["entry_date"]).days
+            reason: str | None = None
+            if ret_pct >= cfg.take_profit_pct:
+                reason = "take_profit"
+            elif ret_pct <= cfg.stop_loss_pct:
+                reason = "stop_loss"
+            elif holding >= cfg.holding_days_max:
+                reason = "time_exit"
+            if reason:
+                exit_price = close_price * (1 - cfg.slippage_pct / 100)
+                gross = (exit_price - pos["entry_price"]) * pos["qty"]
+                commission = (
+                    pos["entry_price"] * pos["qty"] * cfg.commission_pct / 100
+                    + exit_price * pos["qty"] * cfg.commission_pct / 100
+                )
+                pnl = gross - commission
+                cash += exit_price * pos["qty"] - commission / 2
+                trades.append(
+                    Trade(
+                        code=code,
+                        entry_date=pos["entry_date"],
+                        entry_price=pos["entry_price"],
+                        exit_date=d,
+                        exit_price=exit_price,
+                        qty=pos["qty"],
+                        pnl=pnl,
+                        holding_days=holding,
+                        reason=reason,
+                    )
+                )
+                del positions[code]
+
+        # 2) エントリー判定（保有数の余裕がある時のみ）
+        avail = cfg.max_positions - len(positions)
+        if avail > 0 and d in signals:
+            picks = sorted(signals[d], key=lambda kv: kv[1], reverse=True)
+            slot_budget = cash / avail if avail > 0 else 0.0
+            for code, score in picks:
+                if avail <= 0:
+                    break
+                if score < cfg.score_threshold:
+                    continue
+                if code in positions:
+                    continue
+                close_price = prices.get((d, code))
+                if close_price is None or close_price <= 0:
+                    continue
+                # 単元株 = 100株
+                buy_price = close_price * (1 + cfg.slippage_pct / 100)
+                qty = int(slot_budget // (buy_price * 100)) * 100
+                if qty < 100:
+                    continue
+                cost = buy_price * qty * (1 + cfg.commission_pct / 100)
+                if cost > cash:
+                    continue
+                cash -= cost
+                positions[code] = {"entry_date": d, "entry_price": buy_price, "qty": qty}
+                avail -= 1
+
+        # 3) 日次評価額（保有時価評価 + cash）
+        position_value = sum(
+            prices.get((d, c), p["entry_price"]) * p["qty"] for c, p in positions.items()
+        )
+        equity_curve.append((d, cash + position_value))
+
+    # 評価指標
+    if len(equity_curve) >= 2:
+        equity_values = [v for _, v in equity_curve]
+        daily_returns = [
+            (equity_values[i] / equity_values[i - 1]) - 1.0
+            for i in range(1, len(equity_values))
+            if equity_values[i - 1] > 0
+        ]
+    else:
+        daily_returns = []
+    pnls = [t.pnl for t in trades]
+    avg_hold = sum(t.holding_days for t in trades) / len(trades) if trades else 0.0
+    result = BacktestResult(
+        sharpe=sharpe_ratio(daily_returns),
+        max_drawdown=max_drawdown([v for _, v in equity_curve]),
+        win_rate=win_rate(pnls),
+        profit_factor=profit_factor(pnls),
+        avg_holding_days=avg_hold,
+        n_trades=len(trades),
+        equity_curve=equity_curve,
+        trades=trades,
+    )
+
+    if persist:
+        with get_conn() as conn:
+            conn.execute(
+                "INSERT INTO backtest_runs(id, config, start_date, end_date, sharpe, max_drawdown, "
+                "win_rate, profit_factor, avg_holding_days, equity_curve) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                [
+                    str(uuid.uuid4()),
+                    json.dumps(cfg.__dict__),
+                    start,
+                    end,
+                    result.sharpe,
+                    result.max_drawdown,
+                    result.win_rate,
+                    result.profit_factor,
+                    result.avg_holding_days,
+                    json.dumps(
+                        [
+                            {"date": d.isoformat(), "equity": v}
+                            for d, v in equity_curve
+                        ]
+                    ),
+                ],
+            )
+    return result
+
+
+def equity_curve_to_dataframe(result: BacktestResult) -> pd.DataFrame:
+    return pd.DataFrame(result.equity_curve, columns=["date", "equity"])

--- a/src/quantmind/backtest/metrics.py
+++ b/src/quantmind/backtest/metrics.py
@@ -1,0 +1,53 @@
+"""バックテスト評価指標."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def sharpe_ratio(
+    returns: Sequence[float],
+    *,
+    annualization_factor: int = 252,
+    risk_free_rate: float = 0.0,
+) -> float:
+    """日次リターン列から年率シャープレシオを計算."""
+    if len(returns) < 2:
+        return 0.0
+    mean = sum(returns) / len(returns)
+    excess = mean - risk_free_rate / annualization_factor
+    var = sum((r - mean) ** 2 for r in returns) / (len(returns) - 1)
+    std = math.sqrt(var)
+    if std == 0:
+        return 0.0
+    return excess / std * math.sqrt(annualization_factor)
+
+
+def max_drawdown(equity_curve: Sequence[float]) -> float:
+    """資産曲線から最大ドローダウン（負の値）を返す."""
+    if not equity_curve:
+        return 0.0
+    peak = equity_curve[0]
+    mdd = 0.0
+    for value in equity_curve:
+        peak = max(peak, value)
+        if peak <= 0:
+            continue
+        dd = (value / peak) - 1.0
+        mdd = min(mdd, dd)
+    return mdd
+
+
+def profit_factor(trade_pnls: Sequence[float]) -> float:
+    gains = sum(p for p in trade_pnls if p > 0)
+    losses = -sum(p for p in trade_pnls if p < 0)
+    if losses == 0:
+        return float("inf") if gains > 0 else 0.0
+    return gains / losses
+
+
+def win_rate(trade_pnls: Sequence[float]) -> float:
+    if not trade_pnls:
+        return 0.0
+    return sum(1 for p in trade_pnls if p > 0) / len(trade_pnls)

--- a/src/quantmind/backtest/report.py
+++ b/src/quantmind/backtest/report.py
@@ -1,0 +1,53 @@
+"""バックテストの簡易HTMLレポート."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from quantmind.backtest.engine import BacktestResult
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="ja"><head><meta charset="utf-8"><title>QuantMind Backtest Report</title>
+<style>
+body{{font-family:system-ui,'Hiragino Sans','Yu Gothic',sans-serif;margin:24px;color:#222;}}
+h1{{border-bottom:2px solid #444;padding-bottom:6px;}}
+table{{border-collapse:collapse;margin-top:8px;}}
+th,td{{border:1px solid #999;padding:4px 12px;text-align:right;}}
+th{{background:#f4f4f4;}}
+.summary td:first-child, .summary th:first-child{{text-align:left;}}
+.equity{{margin-top:24px;}}
+</style></head><body>
+<h1>バックテスト結果</h1>
+<table class="summary"><tr><th>項目</th><th>値</th></tr>
+<tr><td>シャープレシオ（年率）</td><td>{sharpe:.3f}</td></tr>
+<tr><td>最大ドローダウン</td><td>{max_drawdown:.2%}</td></tr>
+<tr><td>勝率</td><td>{win_rate:.2%}</td></tr>
+<tr><td>プロフィットファクター</td><td>{profit_factor:.3f}</td></tr>
+<tr><td>平均保有日数</td><td>{avg_holding_days:.1f}</td></tr>
+<tr><td>取引回数</td><td>{n_trades}</td></tr>
+</table>
+<div class="equity">
+<h2>資産曲線</h2>
+<table><tr><th>日付</th><th>評価額</th></tr>
+{rows}
+</table>
+</div>
+</body></html>"""
+
+
+def generate_report(result: BacktestResult, out_path: Path) -> Path:
+    rows = "\n".join(
+        f"<tr><td>{d.isoformat()}</td><td>{v:,.0f}</td></tr>" for d, v in result.equity_curve
+    )
+    html = HTML_TEMPLATE.format(
+        sharpe=result.sharpe,
+        max_drawdown=result.max_drawdown,
+        win_rate=result.win_rate,
+        profit_factor=(result.profit_factor if result.profit_factor != float("inf") else 0.0),
+        avg_holding_days=result.avg_holding_days,
+        n_trades=result.n_trades,
+        rows=rows,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html, encoding="utf-8")
+    return out_path

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,114 @@
+"""バックテストエンジンテスト."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from quantmind.backtest import BacktestConfig, generate_report, run_backtest
+from quantmind.backtest.metrics import (
+    max_drawdown,
+    profit_factor,
+    sharpe_ratio,
+    win_rate,
+)
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def test_metrics_basic() -> None:
+    assert sharpe_ratio([0.001, 0.002, 0.003, 0.004]) > 0
+    assert sharpe_ratio([]) == 0.0
+    assert max_drawdown([100, 110, 90, 95, 80]) == pytest.approx((80 / 110) - 1)
+    assert win_rate([1, -1, 2, -2, 3]) == pytest.approx(3 / 5)
+    assert profit_factor([1, -1, 2]) == pytest.approx(3.0)
+
+
+def _seed_market(start: date, end: date) -> None:
+    """連続日付の価格・スクリーニングを投入. 銘柄1個・常時上昇."""
+    with get_conn() as conn:
+        d = start
+        price = 100.0  # 単元株（100株）×40000円予算 で買える価格帯
+        i = 0
+        while d <= end:
+            # 1日1%ずつ上昇
+            close = price * (1.01**i)
+            conn.execute(
+                "INSERT INTO price_daily(code, date, open, high, low, close, volume, source) "
+                "VALUES ('1234', ?, ?, ?, ?, ?, ?, 'fake')",
+                [d, close - 1, close + 1, close - 2, close, 100000],
+            )
+            # 日次スクリーニングでシグナル発生
+            conn.execute(
+                "INSERT INTO screening_daily(date, code, score, rules_hit, rank) "
+                "VALUES (?, '1234', 2.0, ?, 1)",
+                [d, json.dumps(["volume_spike"])],
+            )
+            d += timedelta(days=1)
+            i += 1
+
+
+def test_run_backtest_takes_profit() -> None:
+    start = date(2026, 1, 1)
+    end = date(2026, 1, 31)
+    _seed_market(start, end)
+    cfg = BacktestConfig(
+        initial_cash=200_000,
+        take_profit_pct=8.0,
+        stop_loss_pct=-5.0,
+        holding_days_max=20,
+        score_threshold=1.0,
+    )
+    result = run_backtest(start, end, config=cfg)
+    assert result.n_trades >= 1
+    assert any(t.reason == "take_profit" for t in result.trades)
+    # シャープレシオは正
+    assert result.sharpe > 0
+
+
+def test_run_backtest_persists_to_db() -> None:
+    start = date(2026, 1, 1)
+    end = date(2026, 1, 31)
+    _seed_market(start, end)
+    run_backtest(start, end)
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute("SELECT sharpe, max_drawdown FROM backtest_runs").fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] is not None
+
+
+def test_generate_report_writes_html(tmp_path: Path) -> None:
+    start = date(2026, 1, 1)
+    end = date(2026, 1, 10)
+    _seed_market(start, end)
+    result = run_backtest(start, end, persist=False)
+    out = generate_report(result, tmp_path / "bt.html")
+    assert out.exists()
+    html = out.read_text(encoding="utf-8")
+    assert "シャープレシオ" in html
+    assert "最大ドローダウン" in html
+
+
+def test_no_signals_yields_no_trades() -> None:
+    """スクリーニングなし → 取引ゼロ."""
+    start = date(2026, 1, 1)
+    end = date(2026, 1, 10)
+    with get_conn() as conn:
+        d = start
+        while d <= end:
+            conn.execute(
+                "INSERT INTO price_daily(code, date, open, high, low, close, volume, source) "
+                "VALUES ('1234', ?, 500, 510, 490, 500, 100000, 'fake')",
+                [d],
+            )
+            d += timedelta(days=1)
+    result = run_backtest(start, end, persist=False)
+    assert result.n_trades == 0


### PR DESCRIPTION
## Summary
- 戦略ロジックは #9 の `screening_daily` を信号源として再利用（LLM 不使用）
- 単元株 100株、最大同時保有 (`MAX_POSITIONS`)、現金管理、利食 / 損切 / 時間決済
- 単純なスリッページ・手数料モデル（既定 0.05%）
- 主要指標: **シャープレシオ・最大ドローダウン**、補助で勝率・PF・平均保有日数
- 結果を `backtest_runs` テーブルに保存（config・equity_curve も JSON で残す）
- HTML レポート出力（追加依存なし、自前テンプレート）
- CLI: `python -m quantmind.backtest --start --end --out`

Closes #18

## Test plan
- [x] メトリクス（Sharpe/MaxDD/Win/PF）の計算が正しい
- [x] 上昇相場で take_profit 決済が発生
- [x] 結果が `backtest_runs` に永続化
- [x] HTML レポートに「シャープレシオ」「最大ドローダウン」が含まれる
- [x] スクリーニング無し → 取引ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)