### PR TITLE
chore: make ターゲットでセットアップ・日常運用を一括化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,146 @@
-.PHONY: setup lint format test typecheck check pre-commit clean
+# --------------------------------------------------------------------------
+# QuantMind Makefile
+#
+# 環境変数で挙動を変えられます:
+#   DATE=YYYY-MM-DD   日次系コマンドの対象日（既定: 本日）
+#   OUT=path          レポート出力先
+#   CODES="7203 6758" 銘柄コード一覧（スペース区切り）
+#   START / END       バックテスト期間
+#   REGISTRY=path     IR レジストリ YAML
+#   TOP=10            スクリーニング Top N
+# --------------------------------------------------------------------------
 
+DATE     ?= $(shell date +%Y-%m-%d)
+OUT      ?= reports
+CODES    ?=
+START    ?=
+END      ?=
+REGISTRY ?= src/quantmind/data/ir_docs/registry_sample.yaml
+TOP      ?= 10
+
+UV_RUN := uv run
+
+.PHONY: help setup init-db info run run-pdf run-open backtest \
+        prices tdnet edinet edinet-download ir universe screen \
+        position-list position-history position-summary \
+        lint format test typecheck check pre-commit clean
+
+help:
+	@echo "QuantMind make targets"
+	@echo ""
+	@echo "  セットアップ:"
+	@echo "    make setup          uv sync --all-extras"
+	@echo "    make init-db        DuckDB スキーマ初期化"
+	@echo ""
+	@echo "  日常運用:"
+	@echo "    make info           バージョン確認"
+	@echo "    make run            日次パイプライン → HTML レポート (DATE=)"
+	@echo "    make run-pdf        日次パイプライン → HTML+PDF"
+	@echo "    make run-open       日次パイプライン → HTML を既定ブラウザで開く"
+	@echo "    make backtest       ルールベース戦略のバックテスト (START=, END=)"
+	@echo ""
+	@echo "  データ収集:"
+	@echo "    make prices CODES='7203 6758' [START=YYYY-MM-DD END=YYYY-MM-DD]"
+	@echo "    make tdnet  [DATE=YYYY-MM-DD]"
+	@echo "    make edinet [DATE=YYYY-MM-DD]"
+	@echo "    make edinet-download DOC_ID=Sxxxx [KIND=xbrl|pdf]"
+	@echo "    make ir     [REGISTRY=path/to/registry.yaml] [CODES='1234 5678']"
+	@echo ""
+	@echo "  分析・運用:"
+	@echo "    make universe [DATE=YYYY-MM-DD]"
+	@echo "    make screen   [DATE=YYYY-MM-DD] [TOP=10]"
+	@echo "    make position-list / position-history / position-summary"
+	@echo ""
+	@echo "  開発:"
+	@echo "    make lint format typecheck test check pre-commit clean"
+
+# --- セットアップ -----------------------------------------------------------
 setup:
 	uv sync --all-extras
 
+init-db:
+	$(UV_RUN) python -m quantmind.storage init
+
+# --- 日常運用 ---------------------------------------------------------------
+info:
+	$(UV_RUN) quantmind info
+
+run:
+	$(UV_RUN) quantmind run --date $(DATE) --out $(OUT)
+
+run-pdf:
+	$(UV_RUN) quantmind run --date $(DATE) --out $(OUT) --pdf
+
+run-open:
+	$(UV_RUN) quantmind run --date $(DATE) --out $(OUT) --open
+
+backtest:
+	@if [ -z "$(START)" ] || [ -z "$(END)" ]; then \
+		echo "usage: make backtest START=YYYY-MM-DD END=YYYY-MM-DD [OUT=reports/backtest.html]"; \
+		exit 2; \
+	fi
+	$(UV_RUN) quantmind backtest --start $(START) --end $(END) --out $(OUT)/backtest.html
+
+# --- データ収集 -------------------------------------------------------------
+prices:
+	@if [ -z "$(CODES)" ]; then \
+		echo "usage: make prices CODES='7203 6758' [START=YYYY-MM-DD] [END=YYYY-MM-DD]"; \
+		exit 2; \
+	fi
+	$(UV_RUN) python -m quantmind.data.prices update --codes $(CODES) \
+		$(if $(START),--start $(START)) $(if $(END),--end $(END))
+
+tdnet:
+	$(UV_RUN) python -m quantmind.data.tdnet fetch --date $(DATE)
+
+edinet:
+	$(UV_RUN) python -m quantmind.data.edinet list --date $(DATE)
+
+edinet-download:
+	@if [ -z "$(DOC_ID)" ]; then \
+		echo "usage: make edinet-download DOC_ID=Sxxxx [KIND=xbrl|pdf]"; \
+		exit 2; \
+	fi
+	$(UV_RUN) python -m quantmind.data.edinet download $(DOC_ID) --kind $(or $(KIND),xbrl)
+
+ir:
+	$(UV_RUN) python -m quantmind.data.ir_docs collect --registry $(REGISTRY) \
+		$(if $(CODES),--codes $(CODES))
+
+# --- 分析・運用 -------------------------------------------------------------
+universe:
+	$(UV_RUN) python -m quantmind.universe build --date $(DATE)
+
+screen:
+	$(UV_RUN) python -m quantmind.screening run --date $(DATE) --top $(TOP)
+
+position-list:
+	$(UV_RUN) python -m quantmind.portfolio list
+
+position-history:
+	$(UV_RUN) python -m quantmind.portfolio history
+
+position-summary:
+	$(UV_RUN) python -m quantmind.portfolio summary
+
+# --- 開発 -------------------------------------------------------------------
 lint:
-	uv run ruff check .
+	$(UV_RUN) ruff check .
 
 format:
-	uv run ruff format .
-	uv run ruff check --fix .
+	$(UV_RUN) ruff format .
+	$(UV_RUN) ruff check --fix .
 
 typecheck:
-	uv run mypy src
+	$(UV_RUN) mypy src
 
 test:
-	uv run pytest
+	$(UV_RUN) pytest
 
 check: lint typecheck test
 
 pre-commit:
-	uv run pre-commit run --all-files
+	$(UV_RUN) pre-commit run --all-files
 
 clean:
 	rm -rf .pytest_cache .mypy_cache .ruff_cache htmlcov .coverage

--- a/README.md
+++ b/README.md
@@ -12,26 +12,50 @@
 - [docs/overview.md](docs/overview.md) — 概要（v1.0）
 - [docs/spec.md](docs/spec.md) — 詳細仕様草案（v0.1）
 
-## 開発環境
+## セットアップ
 
 ```bash
-make setup        # uv sync
-make lint         # ruff check
-make format       # ruff format + fix
-make typecheck    # mypy
-make test         # pytest
-make check        # lint + typecheck + test
-make pre-commit   # pre-commit run --all-files
+make setup          # uv sync --all-extras
+make init-db        # DuckDB スキーマ初期化（~/.quantmind/quantmind.duckdb）
 ```
 
-`uv` 単体で使うコマンド:
+データ保存先を変えたい場合は `export QUANTMIND_DATA_DIR=/path/to/dir` を `make init-db` の前に設定してください。
+
+## 日常運用
 
 ```bash
-uv sync                    # 環境同期
-uv run pytest              # テスト
-uv run ruff check .        # Lint
-uv run mypy src            # 型チェック
-uv run quantmind info      # CLI 動作確認
+make info                                    # バージョン確認
+make run                                     # 本日の日次パイプライン → reports/YYYY-MM-DD.html
+make run DATE=2026-05-05                     # 指定日
+make run-open                                # 生成後にブラウザで開く
+make run-pdf                                 # PDF も生成（要 weasyprint）
+make backtest START=2024-01-01 END=2024-12-31
+
+# データ収集
+make prices CODES='7203 6758'                # 株価更新
+make tdnet                                   # 当日 TDnet 開示
+make edinet                                  # 当日 EDINET 提出書類一覧
+make ir REGISTRY=path/to/registry.yaml       # 決算説明資料 PDF
+
+# 分析
+make universe                                # ユニバース構築
+make screen TOP=10                           # ルールベース Top N
+
+# ポジション
+make position-list / position-history / position-summary
+```
+
+利用可能なターゲット一覧は `make help` で確認できます。
+
+## 開発
+
+```bash
+make lint           # ruff check
+make format         # ruff format + fix
+make typecheck      # mypy
+make test           # pytest
+make check          # まとめて全部
+make pre-commit     # pre-commit run --all-files
 ```
 
 ## ステータス


### PR DESCRIPTION
## Summary
- `make setup` / `make init-db` でセットアップが完結
- 日常運用を `make run` / `make run-pdf` / `make run-open` / `make backtest` に集約
- データ収集も `make prices` / `make tdnet` / `make edinet` / `make ir` で一発
- 分析・運用 (`universe` / `screen` / `position-list/history/summary`) も追加
- 環境変数 `DATE` / `CODES` / `START` / `END` / `TOP` などで上書き可
- `make help` でターゲット一覧表示
- README を「セットアップ → 日常運用 → 開発」の順に再構成

## Test plan
- [x] `make help` がターゲット一覧を表示
- [x] `make info` が `quantmind info` を実行しバージョン表示
- [x] 必須引数欠落時（`make backtest` / `make prices` 等）は usage 表示で exit 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)