### PR TITLE
fix: make run / quantmind run の初回起動エラー

### DIFF
--- a/src/quantmind/cli.py
+++ b/src/quantmind/cli.py
@@ -32,7 +32,9 @@ def run_cmd(as_of: str | None, out_dir: str, pdf: bool, open_browser: bool) -> N
     """日次パイプライン実行 → レポート生成."""
     from quantmind.pipeline import run_daily
     from quantmind.report import generate_daily_report
+    from quantmind.storage import init_db
 
+    init_db()  # 初回起動時にスキーマを自動作成（冪等）
     target = date.fromisoformat(as_of) if as_of else date.today()
     pipe_result = run_daily(target)
     paths = generate_daily_report(pipe_result, Path(out_dir), pdf=pdf)
@@ -50,7 +52,9 @@ def run_cmd(as_of: str | None, out_dir: str, pdf: bool, open_browser: bool) -> N
 def backtest_cmd(start: str, end: str, out: str) -> None:
     """ルールベース戦略のバックテスト."""
     from quantmind.backtest import generate_report, run_backtest
+    from quantmind.storage import init_db
 
+    init_db()
     result = run_backtest(date.fromisoformat(start), date.fromisoformat(end))
     click.echo(f"Sharpe: {result.sharpe:.3f}")
     click.echo(f"MaxDD : {result.max_drawdown:.2%}")

--- a/src/quantmind/report/generator.py
+++ b/src/quantmind/report/generator.py
@@ -157,6 +157,7 @@ def generate_daily_report(
 
             pdf_path = out_dir / f"{pipe.as_of.isoformat()}.pdf"
             weasyprint.HTML(string=html).write_pdf(str(pdf_path))
-        except ImportError:
+        except (ImportError, OSError):
+            # weasyprint 未インストール or ネイティブ依存（libgobject等）未解決の場合は HTML のみで継続
             pdf_path = None
     return ReportPaths(html=html_path, pdf=pdf_path)


### PR DESCRIPTION
## Problem
`make run` を初回に叩くと、DuckDB が未初期化のため `_already_done()` の read-only 接続で
\`IO Error: Cannot open database in read-only mode: database does not exist\` が発生していた。

## Fix
- CLI 入口（`quantmind run` / `quantmind backtest`）で `init_db()` を冪等に呼ぶ
  - 初回ユーザーが `make init-db` を忘れていても `make run` が完走する
- PDF 出力時、`weasyprint` のネイティブ依存（libgobject 等）が未解決でも
  `OSError` を握って HTML のみで成功扱いにする（macOS でよく踏む）

## Test plan
- [x] クリーンディレクトリ (`QUANTMIND_DATA_DIR=/tmp/qm_make_test`) で `quantmind run` が完走
- [x] `pytest -q` 92 テスト全パス
- [x] `ruff check` / `mypy` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)