### PR TITLE
feat: add desktop read model

### DIFF
--- a/src/quantmind/desktop/__init__.py
+++ b/src/quantmind/desktop/__init__.py
@@ -1,0 +1,35 @@
+"""Desktop integration read models and service helpers."""
+
+from quantmind.desktop.read_model import (
+    get_daily_summary,
+    get_debate_transcript,
+    get_symbol_detail,
+    list_extracted_symbols,
+    list_run_summaries,
+    search_history,
+)
+from quantmind.desktop.schemas import (
+    DailySummary,
+    DebateMessage,
+    DebateTranscript,
+    ExtractedSymbol,
+    PipelineRunSummary,
+    PipelineStepView,
+    SymbolDetail,
+)
+
+__all__ = [
+    "DailySummary",
+    "DebateMessage",
+    "DebateTranscript",
+    "ExtractedSymbol",
+    "PipelineRunSummary",
+    "PipelineStepView",
+    "SymbolDetail",
+    "get_daily_summary",
+    "get_debate_transcript",
+    "get_symbol_detail",
+    "list_extracted_symbols",
+    "list_run_summaries",
+    "search_history",
+]

--- a/src/quantmind/desktop/read_model.py
+++ b/src/quantmind/desktop/read_model.py
@@ -1,0 +1,371 @@
+"""Read-only desktop view models backed by existing DuckDB tables."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date
+from typing import Any
+
+from quantmind.desktop.schemas import (
+    DailySummary,
+    DebateMessage,
+    DebateTranscript,
+    ExtractedSymbol,
+    PipelineRunSummary,
+    PipelineStepView,
+    SymbolDetail,
+)
+from quantmind.storage import get_conn
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+_ROLE_ORDER = {"bull": 0, "bear": 1, "judge": 2}
+
+
+def _parse_json_list(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [str(item) for item in raw]
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return [raw] if raw else []
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    return []
+
+
+def _parse_json_obj(raw: Any) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _parse_judge_output(text: str, confidence: float | None) -> dict[str, Any]:
+    match = _JSON_RE.search(text or "")
+    if not match:
+        return {
+            "recommendation": None,
+            "confidence": confidence,
+            "summary": (text or "").strip()[:200] or None,
+        }
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return {"recommendation": None, "confidence": confidence, "summary": None}
+    if not isinstance(parsed, dict):
+        return {"recommendation": None, "confidence": confidence, "summary": None}
+    out = dict(parsed)
+    out.setdefault("confidence", confidence)
+    return out
+
+
+def _latest_status(steps: list[PipelineStepView]) -> str:
+    if not steps:
+        return "missing"
+    if any(step.status == "failed" for step in steps):
+        return "failed"
+    if any(step.status == "success" for step in steps):
+        return "success"
+    if any(step.status == "running" for step in steps):
+        return "running"
+    return steps[-1].status
+
+
+def _pipeline_steps_for_date(as_of: date) -> list[PipelineStepView]:
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT step, status, detail, started_at, finished_at "
+            "FROM pipeline_runs WHERE run_date=? "
+            "ORDER BY started_at, finished_at, step",
+            [as_of],
+        ).fetchall()
+    return [
+        PipelineStepView(
+            name=str(step),
+            status=str(status or "missing"),
+            detail=str(detail or ""),
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        for step, status, detail, started_at, finished_at in rows
+    ]
+
+
+def list_run_summaries(limit: int = 30) -> list[PipelineRunSummary]:
+    """Return pipeline run summaries grouped by run date, newest first."""
+    with get_conn(read_only=True) as conn:
+        dates = [
+            row[0]
+            for row in conn.execute(
+                "SELECT run_date FROM pipeline_runs "
+                "WHERE run_date IS NOT NULL GROUP BY run_date "
+                "ORDER BY run_date DESC LIMIT ?",
+                [limit],
+            ).fetchall()
+        ]
+    summaries: list[PipelineRunSummary] = []
+    for run_date in dates:
+        steps = _pipeline_steps_for_date(run_date)
+        starts = [step.started_at for step in steps if step.started_at is not None]
+        finishes = [step.finished_at for step in steps if step.finished_at is not None]
+        summaries.append(
+            PipelineRunSummary(
+                date=run_date,
+                latest_status=_latest_status(steps),
+                started_at=min(starts) if starts else None,
+                finished_at=max(finishes) if finishes else None,
+                steps=steps,
+            )
+        )
+    return summaries
+
+
+def _latest_judges(as_of: date) -> dict[str, dict[str, Any]]:
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            """
+            SELECT code, output, confidence FROM (
+              SELECT code, output, confidence,
+                     ROW_NUMBER() OVER (
+                       PARTITION BY code ORDER BY created_at DESC, id DESC
+                     ) AS rn
+              FROM llm_decisions
+              WHERE as_of_date=? AND role='judge'
+            ) WHERE rn=1
+            """,
+            [as_of],
+        ).fetchall()
+    judges: dict[str, dict[str, Any]] = {}
+    for code, output, confidence in rows:
+        if code is None:
+            continue
+        judges[str(code)] = _parse_judge_output(str(output or ""), confidence)
+    return judges
+
+
+def list_extracted_symbols(
+    as_of: date,
+    *,
+    code: str | None = None,
+    recommendation: str | None = None,
+    min_confidence: float | None = None,
+) -> list[ExtractedSymbol]:
+    """Return ranked screening results enriched with latest judge decision."""
+    query = (
+        "SELECT date, code, score, rules_hit, rank FROM screening_daily WHERE date=?"
+        + (" AND code=?" if code else "")
+        + " ORDER BY rank NULLS LAST, score DESC, code"
+    )
+    params: list[Any] = [as_of]
+    if code:
+        params.append(code)
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(query, params).fetchall()
+
+    judges = _latest_judges(as_of)
+    out: list[ExtractedSymbol] = []
+    for row_date, row_code, score, rules_raw, rank in rows:
+        decision = judges.get(str(row_code), {})
+        rec = decision.get("recommendation")
+        confidence_raw = decision.get("confidence")
+        confidence = float(confidence_raw) if confidence_raw is not None else None
+        if recommendation and rec != recommendation:
+            continue
+        if min_confidence is not None and (confidence is None or confidence < min_confidence):
+            continue
+        out.append(
+            ExtractedSymbol(
+                date=row_date,
+                code=str(row_code),
+                rank=int(rank) if rank is not None else None,
+                score=float(score) if score is not None else None,
+                rules_hit=_parse_json_list(rules_raw),
+                recommendation=str(rec) if rec is not None else None,
+                confidence=confidence,
+                summary=str(decision.get("summary")) if decision.get("summary") is not None else None,
+            )
+        )
+    return out
+
+
+def get_debate_transcript(as_of: date, code: str) -> DebateTranscript:
+    """Return Bull/Bear/Judge messages for a date/code using best-effort grouping."""
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT role, model, prompt, output, confidence, created_at "
+            "FROM llm_decisions WHERE as_of_date=? AND code=? "
+            "AND role IN ('bull', 'bear', 'judge') "
+            "ORDER BY created_at, role",
+            [as_of, code],
+        ).fetchall()
+    messages = [
+        DebateMessage(
+            role=str(role),
+            model=str(model) if model is not None else None,
+            prompt=str(prompt) if prompt is not None else None,
+            output=str(output or ""),
+            confidence=float(confidence) if confidence is not None else None,
+            duration_sec=None,
+            error=None,
+            created_at=created_at,
+        )
+        for role, model, prompt, output, confidence, created_at in rows
+    ]
+    messages.sort(key=lambda msg: (_ROLE_ORDER.get(msg.role, 99), msg.created_at is None, msg.created_at))
+    conversation_id = f"{as_of.isoformat()}:{code}" if messages else None
+    return DebateTranscript(
+        date=as_of,
+        code=code,
+        conversation_id=conversation_id,
+        messages=messages,
+    )
+
+
+def _symbol_scenarios(code: str) -> list[dict[str, Any]]:
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT id, created_at, narrative, quantitative_triggers, qualitative_triggers, "
+            "status, triggered_at FROM falsifiability_scenarios "
+            "WHERE code=? ORDER BY created_at DESC",
+            [code],
+        ).fetchall()
+    return [
+        {
+            "id": str(sid),
+            "created_at": created_at,
+            "narrative": narrative,
+            "quantitative_triggers": _parse_json_list(q_raw),
+            "qualitative_triggers": _parse_json_list(ql_raw),
+            "status": status,
+            "triggered_at": triggered_at,
+        }
+        for sid, created_at, narrative, q_raw, ql_raw, status, triggered_at in rows
+    ]
+
+
+def _symbol_alerts(code: str) -> list[dict[str, Any]]:
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT id, scenario_id, triggered_at, trigger_kind, detail "
+            "FROM alerts WHERE code=? ORDER BY triggered_at DESC",
+            [code],
+        ).fetchall()
+    return [
+        {
+            "id": str(aid),
+            "scenario_id": scenario_id,
+            "triggered_at": triggered_at,
+            "trigger_kind": trigger_kind,
+            "detail": detail,
+        }
+        for aid, scenario_id, triggered_at, trigger_kind, detail in rows
+    ]
+
+
+def get_symbol_detail(as_of: date, code: str) -> SymbolDetail:
+    """Return screening, debate, scenario, and alert details for a symbol/date."""
+    matches = list_extracted_symbols(as_of, code=code)
+    return SymbolDetail(
+        date=as_of,
+        code=code,
+        extracted=matches[0] if matches else None,
+        debate=get_debate_transcript(as_of, code),
+        scenarios=_symbol_scenarios(code),
+        alerts=_symbol_alerts(code),
+    )
+
+
+def get_daily_summary(as_of: date) -> DailySummary:
+    """Return one desktop summary for a trading date."""
+    steps = _pipeline_steps_for_date(as_of)
+    symbols = list_extracted_symbols(as_of)
+    with get_conn(read_only=True) as conn:
+        regime_row = conn.execute(
+            "SELECT regime, score, components FROM macro_regime_daily WHERE date=?",
+            [as_of],
+        ).fetchone()
+    regime = None
+    if regime_row is not None:
+        regime = {
+            "regime": regime_row[0],
+            "score": float(regime_row[1]) if regime_row[1] is not None else None,
+            "components": _parse_json_obj(regime_row[2]),
+        }
+    debate_count = sum(1 for symbol in symbols if symbol.recommendation is not None)
+    return DailySummary(
+        date=as_of,
+        latest_status=_latest_status(steps),
+        steps=steps,
+        extracted_count=len(symbols),
+        debate_count=debate_count,
+        regime=regime,
+    )
+
+
+def search_history(
+    *,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    code: str | None = None,
+    recommendation: str | None = None,
+    min_confidence: float | None = None,
+    pipeline_status: str | None = None,
+    limit: int = 100,
+) -> list[ExtractedSymbol]:
+    """Search historical extracted symbols with UI-oriented filters."""
+    clauses = ["1=1"]
+    params: list[Any] = []
+    if start_date is not None:
+        clauses.append("date>=?")
+        params.append(start_date)
+    if end_date is not None:
+        clauses.append("date<=?")
+        params.append(end_date)
+    if code:
+        clauses.append("code=?")
+        params.append(code)
+    params.append(limit)
+    with get_conn(read_only=True) as conn:
+        dates = [
+            row[0]
+            for row in conn.execute(
+                f"SELECT DISTINCT date FROM screening_daily WHERE {' AND '.join(clauses)} "
+                "ORDER BY date DESC LIMIT ?",
+                params,
+            ).fetchall()
+        ]
+
+    out: list[ExtractedSymbol] = []
+    allowed_dates = set(dates)
+    if pipeline_status:
+        allowed_dates = {
+            summary.date
+            for summary in list_run_summaries(limit=limit)
+            if summary.date in allowed_dates and summary.latest_status == pipeline_status
+        }
+    for run_date in dates:
+        if run_date not in allowed_dates:
+            continue
+        out.extend(
+            list_extracted_symbols(
+                run_date,
+                code=code,
+                recommendation=recommendation,
+                min_confidence=min_confidence,
+            )
+        )
+        if len(out) >= limit:
+            return out[:limit]
+    return out

--- a/src/quantmind/desktop/schemas.py
+++ b/src/quantmind/desktop/schemas.py
@@ -1,0 +1,73 @@
+"""Pydantic schemas shared by desktop read models and RPC."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+PipelineStatus = Literal["success", "skipped", "failed", "running", "missing"]
+
+
+class PipelineStepView(BaseModel):
+    name: str
+    status: PipelineStatus | str
+    detail: str = ""
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class PipelineRunSummary(BaseModel):
+    date: date
+    latest_status: PipelineStatus | str
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    steps: list[PipelineStepView] = Field(default_factory=list)
+
+
+class ExtractedSymbol(BaseModel):
+    date: date
+    code: str
+    rank: int | None = None
+    score: float | None = None
+    rules_hit: list[str] = Field(default_factory=list)
+    recommendation: str | None = None
+    confidence: float | None = None
+    summary: str | None = None
+
+
+class DebateMessage(BaseModel):
+    role: str
+    model: str | None = None
+    prompt: str | None = None
+    output: str
+    confidence: float | None = None
+    duration_sec: float | None = None
+    error: str | None = None
+    created_at: datetime | None = None
+
+
+class DebateTranscript(BaseModel):
+    date: date
+    code: str
+    conversation_id: str | None = None
+    messages: list[DebateMessage] = Field(default_factory=list)
+
+
+class SymbolDetail(BaseModel):
+    date: date
+    code: str
+    extracted: ExtractedSymbol | None = None
+    debate: DebateTranscript
+    scenarios: list[dict[str, Any]] = Field(default_factory=list)
+    alerts: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DailySummary(BaseModel):
+    date: date
+    latest_status: PipelineStatus | str
+    steps: list[PipelineStepView] = Field(default_factory=list)
+    extracted_count: int = 0
+    debate_count: int = 0
+    regime: dict[str, Any] | None = None

--- a/tests/test_desktop_read_model.py
+++ b/tests/test_desktop_read_model.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+from quantmind.desktop import (
+    get_daily_summary,
+    get_debate_transcript,
+    get_symbol_detail,
+    list_extracted_symbols,
+    list_run_summaries,
+    search_history,
+)
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def _seed_desktop_rows() -> None:
+    judge = {
+        "recommendation": "buy",
+        "confidence": 0.81,
+        "summary": "出来高急増と開示材料が揃っている",
+    }
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO screening_daily(date, code, score, rules_hit, rank) "
+            "VALUES (?, '1234', 4.2, ?, 1)",
+            [date(2026, 5, 5), json.dumps(["volume_spike", "tdnet_today"])],
+        )
+        conn.execute(
+            "INSERT INTO macro_regime_daily(date, regime, score, components) VALUES (?, ?, ?, ?)",
+            [date(2026, 5, 5), "risk_on", 0.72, json.dumps({"vix": 18.0})],
+        )
+        for idx, (role, output, confidence) in enumerate(
+            [
+                ("bull", "bull output", None),
+                ("bear", "bear output", None),
+                ("judge", json.dumps(judge, ensure_ascii=False), 0.81),
+            ],
+            start=1,
+        ):
+            conn.execute(
+                "INSERT INTO llm_decisions(id, code, as_of_date, role, model, prompt, output, confidence, created_at) "
+                "VALUES (?, '1234', ?, ?, 'fake', ?, ?, ?, ?)",
+                [
+                    f"llm-{idx}",
+                    date(2026, 5, 5),
+                    role,
+                    f"{role} prompt",
+                    output,
+                    confidence,
+                    datetime(2026, 5, 5, 9, idx),
+                ],
+            )
+        conn.execute(
+            "INSERT INTO pipeline_runs(id, run_date, step, status, detail, started_at, finished_at) "
+            "VALUES ('run-1', ?, 'screening', 'success', '', ?, ?)",
+            [
+                date(2026, 5, 5),
+                datetime(2026, 5, 5, 9, 0),
+                datetime(2026, 5, 5, 9, 1),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO falsifiability_scenarios(id, code, narrative, quantitative_triggers, qualitative_triggers, status) "
+            "VALUES ('scenario-1', '1234', '崩れる条件', ?, ?, 'active')",
+            [json.dumps(["drawdown_pct"]), json.dumps(["競合リスク"])],
+        )
+        conn.execute(
+            "INSERT INTO alerts(id, code, scenario_id, trigger_kind, detail) "
+            "VALUES ('alert-1', '1234', 'scenario-1', 'quantitative', 'drawdown_pct')",
+        )
+
+
+def test_list_extracted_symbols_enriches_screening_with_latest_judge() -> None:
+    _seed_desktop_rows()
+
+    symbols = list_extracted_symbols(date(2026, 5, 5))
+
+    assert len(symbols) == 1
+    assert symbols[0].code == "1234"
+    assert symbols[0].rank == 1
+    assert symbols[0].rules_hit == ["volume_spike", "tdnet_today"]
+    assert symbols[0].recommendation == "buy"
+    assert symbols[0].confidence == pytest.approx(0.81)
+
+
+def test_debate_transcript_restores_bull_bear_judge_messages() -> None:
+    _seed_desktop_rows()
+
+    transcript = get_debate_transcript(date(2026, 5, 5), "1234")
+
+    assert transcript.conversation_id == "2026-05-05:1234"
+    assert [msg.role for msg in transcript.messages] == ["bull", "bear", "judge"]
+    assert transcript.messages[0].prompt == "bull prompt"
+
+
+def test_symbol_detail_includes_scenarios_and_alerts() -> None:
+    _seed_desktop_rows()
+
+    detail = get_symbol_detail(date(2026, 5, 5), "1234")
+
+    assert detail.extracted is not None
+    assert detail.debate.messages
+    assert detail.scenarios[0]["id"] == "scenario-1"
+    assert detail.alerts[0]["id"] == "alert-1"
+
+
+def test_daily_summary_and_run_summaries_are_read_only() -> None:
+    _seed_desktop_rows()
+    with get_conn(read_only=True) as conn:
+        before = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
+
+    summary = get_daily_summary(date(2026, 5, 5))
+    runs = list_run_summaries()
+
+    with get_conn(read_only=True) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
+    assert before == after
+    assert summary.latest_status == "success"
+    assert summary.extracted_count == 1
+    assert summary.debate_count == 1
+    assert runs[0].date == date(2026, 5, 5)
+
+
+def test_search_history_filters_recommendation_and_confidence() -> None:
+    _seed_desktop_rows()
+
+    assert search_history(recommendation="buy", min_confidence=0.8)[0].code == "1234"
+    assert search_history(recommendation="watch") == []


### PR DESCRIPTION
## Summary
- Add quantmind.desktop schemas and read-model helpers for pipeline runs, daily summaries, extracted symbols, symbol details, and debate transcripts
- Reconstruct existing screening_daily, llm_decisions, pipeline_runs, scenarios, and alerts without introducing a second data store
- Add read-only unit tests covering symbol enrichment, transcript restore, details, summaries, and search filters

Closes #44

## Verification
- uv run pytest tests/test_desktop_read_model.py
- uv run ruff check src/quantmind/desktop tests/test_desktop_read_model.py
- uv run mypy src
- uv run pytest