### PR TITLE
feat: persist debate conversations

### DIFF
--- a/src/quantmind/desktop/read_model.py
+++ b/src/quantmind/desktop/read_model.py
@@ -203,28 +203,48 @@ def list_extracted_symbols(
 def get_debate_transcript(as_of: date, code: str) -> DebateTranscript:
     """Return Bull/Bear/Judge messages for a date/code using best-effort grouping."""
     with get_conn(read_only=True) as conn:
-        rows = conn.execute(
-            "SELECT role, model, prompt, output, confidence, created_at "
-            "FROM llm_decisions WHERE as_of_date=? AND code=? "
-            "AND role IN ('bull', 'bear', 'judge') "
-            "ORDER BY created_at, role",
+        latest = conn.execute(
+            "SELECT conversation_id FROM llm_decisions "
+            "WHERE as_of_date=? AND code=? AND role IN ('bull', 'bear', 'judge') "
+            "AND conversation_id IS NOT NULL "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
             [as_of, code],
-        ).fetchall()
+        ).fetchone()
+        conversation_id = str(latest[0]) if latest and latest[0] is not None else None
+        if conversation_id:
+            rows = conn.execute(
+                "SELECT role, model, system_prompt, prompt, output, confidence, "
+                "duration_sec, error, created_at "
+                "FROM llm_decisions WHERE as_of_date=? AND code=? AND conversation_id=? "
+                "AND role IN ('bull', 'bear', 'judge') "
+                "ORDER BY created_at, role",
+                [as_of, code, conversation_id],
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT role, model, system_prompt, prompt, output, confidence, "
+                "duration_sec, error, created_at "
+                "FROM llm_decisions WHERE as_of_date=? AND code=? "
+                "AND role IN ('bull', 'bear', 'judge') "
+                "ORDER BY created_at, role",
+                [as_of, code],
+            ).fetchall()
     messages = [
         DebateMessage(
             role=str(role),
             model=str(model) if model is not None else None,
+            system_prompt=str(system_prompt) if system_prompt is not None else None,
             prompt=str(prompt) if prompt is not None else None,
             output=str(output or ""),
             confidence=float(confidence) if confidence is not None else None,
-            duration_sec=None,
-            error=None,
+            duration_sec=float(duration_sec) if duration_sec is not None else None,
+            error=str(error) if error is not None else None,
             created_at=created_at,
         )
-        for role, model, prompt, output, confidence, created_at in rows
+        for role, model, system_prompt, prompt, output, confidence, duration_sec, error, created_at in rows
     ]
     messages.sort(key=lambda msg: (_ROLE_ORDER.get(msg.role, 99), msg.created_at is None, msg.created_at))
-    conversation_id = f"{as_of.isoformat()}:{code}" if messages else None
+    conversation_id = conversation_id or (f"{as_of.isoformat()}:{code}" if messages else None)
     return DebateTranscript(
         date=as_of,
         code=code,

--- a/src/quantmind/desktop/schemas.py
+++ b/src/quantmind/desktop/schemas.py
@@ -40,6 +40,7 @@ class ExtractedSymbol(BaseModel):
 class DebateMessage(BaseModel):
     role: str
     model: str | None = None
+    system_prompt: str | None = None
     prompt: str | None = None
     output: str
     confidence: float | None = None

--- a/src/quantmind/llm/debate.py
+++ b/src/quantmind/llm/debate.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 import re
+import uuid
 from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 from typing import Any
 
-from quantmind.llm.runner import LLMResponse, LLMRunner, log_decision
+from quantmind.llm.runner import LLMResponse, LLMRunner, log_decision, log_decision_error
 from quantmind.storage import get_conn
 
 PROMPTS_DIR = Path(__file__).parent / "prompts"
@@ -93,27 +94,79 @@ def run_debate(
     *,
     as_of: date | None = None,
     persist: bool = True,
+    conversation_id: str | None = None,
 ) -> DebateResult:
     """1銘柄に対し Bull → Bear → Judge を順に実行."""
+    conversation_id = conversation_id or str(uuid.uuid4())
     bull_template = _load_prompt("bull")
     bear_template = _load_prompt("bear")
     judge_template = _load_prompt("judge")
 
     bull_prompt = _format_prompt(bull_template, **context.__dict__)
-    bull_resp: LLMResponse = bull_runner.run(
-        system_prompt="You are a careful Japanese equities analyst (Bull).",
-        user_prompt=bull_prompt,
-    )
+    bull_system_prompt = "You are a careful Japanese equities analyst (Bull)."
+    try:
+        bull_resp: LLMResponse = bull_runner.run(
+            system_prompt=bull_system_prompt,
+            user_prompt=bull_prompt,
+        )
+    except Exception as e:
+        if persist:
+            log_decision_error(
+                code=context.code,
+                role="bull",
+                model=getattr(bull_runner, "name", "unknown"),
+                prompt=bull_prompt,
+                system_prompt=bull_system_prompt,
+                error=f"{type(e).__name__}: {e}",
+                as_of=as_of,
+                conversation_id=conversation_id,
+            )
+        raise
+    if persist:
+        log_decision(
+            code=context.code,
+            role="bull",
+            response=bull_resp,
+            prompt=bull_prompt,
+            system_prompt=bull_system_prompt,
+            as_of=as_of,
+            conversation_id=conversation_id,
+        )
 
     bear_prompt = _format_prompt(
         bear_template,
         bull_text=bull_resp.text,
         **context.__dict__,
     )
-    bear_resp: LLMResponse = bear_runner.run(
-        system_prompt="You are a critical Japanese equities analyst (Bear).",
-        user_prompt=bear_prompt,
-    )
+    bear_system_prompt = "You are a critical Japanese equities analyst (Bear)."
+    try:
+        bear_resp: LLMResponse = bear_runner.run(
+            system_prompt=bear_system_prompt,
+            user_prompt=bear_prompt,
+        )
+    except Exception as e:
+        if persist:
+            log_decision_error(
+                code=context.code,
+                role="bear",
+                model=getattr(bear_runner, "name", "unknown"),
+                prompt=bear_prompt,
+                system_prompt=bear_system_prompt,
+                error=f"{type(e).__name__}: {e}",
+                as_of=as_of,
+                conversation_id=conversation_id,
+            )
+        raise
+    if persist:
+        log_decision(
+            code=context.code,
+            role="bear",
+            response=bear_resp,
+            prompt=bear_prompt,
+            system_prompt=bear_system_prompt,
+            as_of=as_of,
+            conversation_id=conversation_id,
+        )
 
     judge_prompt = _format_prompt(
         judge_template,
@@ -122,10 +175,25 @@ def run_debate(
         code=context.code,
         name=context.name,
     )
-    judge_resp: LLMResponse = judge_runner.run(
-        system_prompt="You are a neutral judge. Output JSON only.",
-        user_prompt=judge_prompt,
-    )
+    judge_system_prompt = "You are a neutral judge. Output JSON only."
+    try:
+        judge_resp: LLMResponse = judge_runner.run(
+            system_prompt=judge_system_prompt,
+            user_prompt=judge_prompt,
+        )
+    except Exception as e:
+        if persist:
+            log_decision_error(
+                code=context.code,
+                role="judge",
+                model=getattr(judge_runner, "name", "unknown"),
+                prompt=judge_prompt,
+                system_prompt=judge_system_prompt,
+                error=f"{type(e).__name__}: {e}",
+                as_of=as_of,
+                conversation_id=conversation_id,
+            )
+        raise
 
     parsed = _parse_judge_output(judge_resp.text)
     confidence_raw = parsed.get("confidence", 0.0)
@@ -136,18 +204,14 @@ def run_debate(
 
     if persist:
         log_decision(
-            code=context.code, role="bull", response=bull_resp, prompt=bull_prompt, as_of=as_of
-        )
-        log_decision(
-            code=context.code, role="bear", response=bear_resp, prompt=bear_prompt, as_of=as_of
-        )
-        log_decision(
             code=context.code,
             role="judge",
             response=judge_resp,
             prompt=judge_prompt,
+            system_prompt=judge_system_prompt,
             confidence=confidence,
             as_of=as_of,
+            conversation_id=conversation_id,
         )
 
     return DebateResult(
@@ -165,23 +229,30 @@ def run_debate(
 
 def load_debates(as_of: date) -> list[DebateResult]:
     """保存済み Bull/Bear/Judge の判断ログからディベート結果を復元する."""
-    grouped: dict[str, dict[str, tuple[str, float | None]]] = {}
+    grouped: dict[tuple[str, str], dict[str, tuple[str, float | None]]] = {}
+    latest_created: dict[tuple[str, str], Any] = {}
     with get_conn(read_only=True) as conn:
         rows = conn.execute(
-            "SELECT code, role, output, confidence FROM llm_decisions "
+            "SELECT code, role, output, confidence, conversation_id, created_at FROM llm_decisions "
             "WHERE as_of_date=? AND role IN ('bull', 'bear', 'judge') "
-            "ORDER BY code, role, created_at DESC",
+            "ORDER BY code, created_at DESC, role",
             [as_of],
         ).fetchall()
 
-    for code, role, output, confidence in rows:
+    for code, role, output, confidence, conversation_id, created_at in rows:
         if code is None or role is None:
             continue
-        by_role = grouped.setdefault(str(code), {})
+        group_id = str(conversation_id or f"legacy:{code}")
+        key = (str(code), group_id)
+        by_role = grouped.setdefault(key, {})
         by_role.setdefault(str(role), (str(output or ""), confidence))
+        if key not in latest_created or created_at > latest_created[key]:
+            latest_created[key] = created_at
 
     out: list[DebateResult] = []
-    for code, by_role in sorted(grouped.items()):
+    for (code, _group_id), by_role in sorted(
+        grouped.items(), key=lambda item: (item[0][0], latest_created.get(item[0])), reverse=True
+    ):
         if not {"bull", "bear", "judge"} <= by_role.keys():
             continue
         bull_text = by_role["bull"][0]

--- a/src/quantmind/llm/runner.py
+++ b/src/quantmind/llm/runner.py
@@ -140,17 +140,74 @@ def log_decision(
     role: str,
     response: LLMResponse,
     prompt: str,
+    system_prompt: str | None = None,
     confidence: float | None = None,
     as_of: date | None = None,
     decision_id: str | None = None,
+    conversation_id: str | None = None,
+    error: str | None = None,
 ) -> str:
     """llm_decisions テーブルに保存."""
     did = decision_id or str(uuid.uuid4())
     with get_conn() as conn:
         conn.execute(
-            "INSERT INTO llm_decisions(id, code, as_of_date, role, model, prompt, output, confidence) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            [did, code, as_of, role, response.model, prompt, response.text, confidence],
+            "INSERT INTO llm_decisions("
+            "id, code, as_of_date, role, model, prompt, output, confidence, "
+            "conversation_id, system_prompt, duration_sec, error"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                did,
+                code,
+                as_of,
+                role,
+                response.model,
+                prompt,
+                response.text,
+                confidence,
+                conversation_id,
+                system_prompt,
+                response.duration_sec,
+                error,
+            ],
+        )
+    return did
+
+
+def log_decision_error(
+    *,
+    code: str | None,
+    role: str,
+    model: str,
+    prompt: str,
+    error: str,
+    system_prompt: str | None = None,
+    as_of: date | None = None,
+    decision_id: str | None = None,
+    conversation_id: str | None = None,
+    duration_sec: float | None = None,
+) -> str:
+    """失敗した LLM 実行を llm_decisions に保存."""
+    did = decision_id or str(uuid.uuid4())
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO llm_decisions("
+            "id, code, as_of_date, role, model, prompt, output, confidence, "
+            "conversation_id, system_prompt, duration_sec, error"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                did,
+                code,
+                as_of,
+                role,
+                model,
+                prompt,
+                "",
+                None,
+                conversation_id,
+                system_prompt,
+                duration_sec,
+                error,
+            ],
         )
     return did
 

--- a/src/quantmind/storage/migrations/0002_llm_conversations.sql
+++ b/src/quantmind/storage/migrations/0002_llm_conversations.sql
@@ -1,0 +1,9 @@
+-- Conversation-level metadata for Claude Code/Codex debate transcripts.
+
+ALTER TABLE llm_decisions ADD COLUMN IF NOT EXISTS conversation_id VARCHAR;
+ALTER TABLE llm_decisions ADD COLUMN IF NOT EXISTS system_prompt TEXT;
+ALTER TABLE llm_decisions ADD COLUMN IF NOT EXISTS duration_sec DOUBLE;
+ALTER TABLE llm_decisions ADD COLUMN IF NOT EXISTS error TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_llm_decisions_conversation
+ON llm_decisions(as_of_date, code, conversation_id);

--- a/tests/test_debate.py
+++ b/tests/test_debate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from quantmind.llm import StockContext, run_debate
-from quantmind.llm.runner import LLMResponse
+from quantmind.llm.runner import LLMResponse, LLMRunError
 from quantmind.storage import get_conn, init_db
 
 
@@ -35,6 +35,13 @@ class FakeRunner:
             raw_stderr="",
             duration_sec=0.001,
         )
+
+
+class FailingRunner:
+    name = "failing"
+
+    def run(self, system_prompt: str, user_prompt: str, timeout: int = 180) -> LLMResponse:
+        raise LLMRunError("boom")
 
 
 JUDGE_OK = json.dumps(
@@ -74,6 +81,60 @@ def test_run_debate_persists_three_decisions() -> None:
             ).fetchall()
         ]
     assert roles == ["bear", "bull", "judge"]
+
+
+def test_run_debate_persists_conversation_metadata() -> None:
+    bull = FakeRunner("bull text")
+    bear = FakeRunner("bear text")
+    judge = FakeRunner(JUDGE_OK)
+    ctx = StockContext(code="8888")
+
+    run_debate(
+        bull,
+        bear,
+        judge,
+        ctx,
+        as_of=date(2026, 4, 30),
+        conversation_id="conversation-1",
+    )
+
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT role, conversation_id, system_prompt, duration_sec, error "
+            "FROM llm_decisions WHERE code='8888' ORDER BY role"
+        ).fetchall()
+    assert {row[1] for row in rows} == {"conversation-1"}
+    assert all(row[2] for row in rows)
+    assert all(row[3] == pytest.approx(0.001) for row in rows)
+    assert all(row[4] is None for row in rows)
+
+
+def test_run_debate_persists_failed_conversation_stage() -> None:
+    bull = FakeRunner("bull text")
+    bear = FailingRunner()
+    judge = FakeRunner(JUDGE_OK)
+
+    with pytest.raises(LLMRunError):
+        run_debate(
+            bull,
+            bear,
+            judge,
+            StockContext(code="7777"),
+            as_of=date(2026, 4, 30),
+            conversation_id="conversation-failed",
+        )
+
+    with get_conn(read_only=True) as conn:
+        rows = conn.execute(
+            "SELECT role, conversation_id, output, error FROM llm_decisions "
+            "WHERE code='7777' ORDER BY role"
+        ).fetchall()
+    assert [(row[0], row[1]) for row in rows] == [
+        ("bear", "conversation-failed"),
+        ("bull", "conversation-failed"),
+    ]
+    assert rows[0][2] == ""
+    assert "LLMRunError: boom" in rows[0][3]
 
 
 def test_judge_output_parser_recovers_from_extra_text() -> None:

--- a/tests/test_desktop_read_model.py
+++ b/tests/test_desktop_read_model.py
@@ -103,6 +103,41 @@ def test_debate_transcript_restores_bull_bear_judge_messages() -> None:
     assert transcript.messages[0].prompt == "bull prompt"
 
 
+def test_debate_transcript_prefers_latest_conversation_group() -> None:
+    with get_conn() as conn:
+        for idx, (conversation_id, marker, hour) in enumerate(
+            [
+                ("conversation-old", "old", 8),
+                ("conversation-new", "new", 9),
+            ],
+            start=1,
+        ):
+            for role_index, role in enumerate(["bull", "bear", "judge"], start=1):
+                conn.execute(
+                    "INSERT INTO llm_decisions("
+                    "id, code, as_of_date, role, model, system_prompt, prompt, output, "
+                    "conversation_id, duration_sec, error, created_at"
+                    ") VALUES (?, '9999', ?, ?, 'fake', ?, ?, ?, ?, 0.2, NULL, ?)",
+                    [
+                        f"conv-{idx}-{role}",
+                        date(2026, 5, 5),
+                        role,
+                        f"{role} system",
+                        f"{role} prompt",
+                        f"{marker} {role}",
+                        conversation_id,
+                        datetime(2026, 5, 5, hour, role_index),
+                    ],
+                )
+
+    transcript = get_debate_transcript(date(2026, 5, 5), "9999")
+
+    assert transcript.conversation_id == "conversation-new"
+    assert [msg.output for msg in transcript.messages] == ["new bull", "new bear", "new judge"]
+    assert transcript.messages[0].system_prompt == "bull system"
+    assert transcript.messages[0].duration_sec == pytest.approx(0.2)
+
+
 def test_symbol_detail_includes_scenarios_and_alerts() -> None:
     _seed_desktop_rows()
 


### PR DESCRIPTION
## Summary
- Add llm_decisions conversation metadata migration: conversation_id, system_prompt, duration_sec, error
- Persist Bull/Bear/Judge stages under one conversation id and record failed stages before re-raising
- Teach the desktop read model to prefer the latest conversation group while preserving legacy date/code restoration

Closes #45

## Verification
- uv run pytest tests/test_debate.py tests/test_desktop_read_model.py
- uv run ruff check src/quantmind/llm src/quantmind/desktop src/quantmind/storage tests/test_debate.py tests/test_desktop_read_model.py
- uv run mypy src
- uv run pytest