### PR TITLE
feat: expose desktop read RPC

### DIFF
--- a/src/quantmind/desktop/__main__.py
+++ b/src/quantmind/desktop/__main__.py
@@ -1,0 +1,6 @@
+"""Run the desktop JSON-RPC server."""
+
+from quantmind.desktop.rpc_server import main
+
+if __name__ == "__main__":
+    main()

--- a/src/quantmind/desktop/rpc_server.py
+++ b/src/quantmind/desktop/rpc_server.py
@@ -1,0 +1,190 @@
+"""JSON-RPC 2.0 server for the Electron desktop app.
+
+The runtime transport is newline-delimited JSON over stdio. Tests call
+``handle_jsonrpc`` directly so the method surface stays stable without spawning
+an Electron process.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from pydantic import BaseModel
+
+from quantmind.desktop import read_model
+
+JsonDict = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RpcError(Exception):
+    code: int
+    message: str
+    data: JsonDict | None = None
+
+
+def _parse_date(value: Any, name: str = "date") -> date:
+    if isinstance(value, date):
+        return value
+    if not isinstance(value, str):
+        raise RpcError(-32602, "validation_error", {"field": name, "detail": "expected YYYY-MM-DD"})
+    try:
+        return date.fromisoformat(value)
+    except ValueError as e:
+        raise RpcError(-32602, "validation_error", {"field": name, "detail": str(e)}) from e
+
+
+def _params(raw: Any) -> JsonDict:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise RpcError(-32602, "validation_error", {"detail": "params must be an object"})
+    return raw
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return json.loads(value.model_dump_json())
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _desktop_list_runs(params: JsonDict) -> Any:
+    return read_model.list_run_summaries(limit=int(params.get("limit", 30)))
+
+
+def _desktop_get_daily_summary(params: JsonDict) -> Any:
+    return read_model.get_daily_summary(_parse_date(params.get("date")))
+
+
+def _desktop_list_extracted_symbols(params: JsonDict) -> Any:
+    return read_model.list_extracted_symbols(
+        _parse_date(params.get("date")),
+        code=params.get("code"),
+        recommendation=params.get("recommendation"),
+        min_confidence=params.get("min_confidence"),
+    )
+
+
+def _desktop_get_symbol_detail(params: JsonDict) -> Any:
+    code = params.get("code")
+    if not isinstance(code, str) or not code:
+        raise RpcError(-32602, "validation_error", {"field": "code", "detail": "required"})
+    return read_model.get_symbol_detail(_parse_date(params.get("date")), code)
+
+
+def _desktop_get_debate_transcript(params: JsonDict) -> Any:
+    code = params.get("code")
+    if not isinstance(code, str) or not code:
+        raise RpcError(-32602, "validation_error", {"field": "code", "detail": "required"})
+    return read_model.get_debate_transcript(_parse_date(params.get("date")), code)
+
+
+def _desktop_search_history(params: JsonDict) -> Any:
+    return read_model.search_history(
+        start_date=_parse_date(params["start_date"], "start_date")
+        if params.get("start_date")
+        else None,
+        end_date=_parse_date(params["end_date"], "end_date") if params.get("end_date") else None,
+        code=params.get("code"),
+        recommendation=params.get("recommendation"),
+        min_confidence=params.get("min_confidence"),
+        pipeline_status=params.get("pipeline_status"),
+        limit=int(params.get("limit", 100)),
+    )
+
+
+METHODS: dict[str, Callable[[JsonDict], Any]] = {
+    "desktop.list_runs": _desktop_list_runs,
+    "desktop.get_daily_summary": _desktop_get_daily_summary,
+    "desktop.list_extracted_symbols": _desktop_list_extracted_symbols,
+    "desktop.get_symbol_detail": _desktop_get_symbol_detail,
+    "desktop.get_debate_transcript": _desktop_get_debate_transcript,
+    "desktop.search_history": _desktop_search_history,
+}
+
+
+def handle_jsonrpc(request: JsonDict) -> JsonDict | None:
+    """Handle one JSON-RPC request object."""
+    request_id = request.get("id")
+    if request.get("jsonrpc") != "2.0":
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32600, "message": "invalid_request"},
+        }
+    method_name = request.get("method")
+    if not isinstance(method_name, str):
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32600, "message": "invalid_request"},
+        }
+    method = METHODS.get(method_name)
+    if method is None:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32601, "message": "method_not_found"},
+        }
+    try:
+        result = method(_params(request.get("params")))
+    except RpcError as e:
+        error: JsonDict = {"code": e.code, "message": e.message}
+        if e.data is not None:
+            error["data"] = e.data
+        return {"jsonrpc": "2.0", "id": request_id, "error": error}
+    except Exception as e:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": -32603,
+                "message": "internal_error",
+                "data": {"detail": f"{type(e).__name__}: {e}"},
+            },
+        }
+    if request_id is None:
+        return None
+    return {"jsonrpc": "2.0", "id": request_id, "result": _jsonable(result)}
+
+
+def serve(input_stream: Any = sys.stdin, output_stream: Any = sys.stdout) -> None:
+    """Serve newline-delimited JSON-RPC over stdio."""
+    for line in input_stream:
+        if not line.strip():
+            continue
+        response: JsonDict | None
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError as e:
+            response = {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32700,
+                    "message": "parse_error",
+                    "data": {"detail": str(e)},
+                },
+            }
+        else:
+            response = handle_jsonrpc(raw) if isinstance(raw, dict) else None
+        if response is not None:
+            output_stream.write(json.dumps(response, ensure_ascii=False) + "\n")
+            output_stream.flush()
+
+
+def main() -> None:
+    serve()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_desktop_rpc.py
+++ b/tests/test_desktop_rpc.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+from quantmind.desktop.rpc_server import handle_jsonrpc
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def _seed_rows() -> None:
+    judge = {
+        "recommendation": "buy",
+        "confidence": 0.76,
+        "summary": "材料と価格反応が揃っている",
+    }
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO screening_daily(date, code, score, rules_hit, rank) "
+            "VALUES (?, '1234', 3.5, ?, 1)",
+            [date(2026, 5, 5), json.dumps(["tdnet_today"])],
+        )
+        conn.execute(
+            "INSERT INTO llm_decisions("
+            "id, code, as_of_date, role, model, system_prompt, prompt, output, "
+            "confidence, conversation_id, duration_sec, created_at"
+            ") VALUES ('judge-1', '1234', ?, 'judge', 'fake', 'judge system', "
+            "'judge prompt', ?, 0.76, 'conversation-1', 0.1, ?)",
+            [date(2026, 5, 5), json.dumps(judge, ensure_ascii=False), datetime(2026, 5, 5, 9)],
+        )
+        conn.execute(
+            "INSERT INTO pipeline_runs(id, run_date, step, status, detail, started_at, finished_at) "
+            "VALUES ('run-1', ?, 'screening', 'success', '', ?, ?)",
+            [
+                date(2026, 5, 5),
+                datetime(2026, 5, 5, 9, 0),
+                datetime(2026, 5, 5, 9, 1),
+            ],
+        )
+
+
+def _request(method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+    response = handle_jsonrpc({"jsonrpc": "2.0", "id": "1", "method": method, "params": params or {}})
+    assert response is not None
+    return response
+
+
+def test_list_extracted_symbols_rpc_returns_json_schema() -> None:
+    _seed_rows()
+
+    response = _request("desktop.list_extracted_symbols", {"date": "2026-05-05"})
+
+    result = response["result"]
+    assert isinstance(result, list)
+    assert result[0]["date"] == "2026-05-05"
+    assert result[0]["code"] == "1234"
+    assert result[0]["rules_hit"] == ["tdnet_today"]
+    assert result[0]["recommendation"] == "buy"
+
+
+def test_read_only_rpc_does_not_mutate_pipeline_runs() -> None:
+    _seed_rows()
+    with get_conn(read_only=True) as conn:
+        before = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
+
+    response = _request("desktop.get_daily_summary", {"date": "2026-05-05"})
+
+    with get_conn(read_only=True) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
+    assert before == after
+    assert response["result"]["latest_status"] == "success"
+
+
+def test_missing_date_returns_stable_empty_summary() -> None:
+    response = _request("desktop.get_daily_summary", {"date": "2026-05-06"})
+
+    assert response["result"]["latest_status"] == "missing"
+    assert response["result"]["extracted_count"] == 0
+    assert response["result"]["steps"] == []
+
+
+def test_invalid_params_are_jsonrpc_errors() -> None:
+    response = _request("desktop.get_symbol_detail", {"date": "bad", "code": "1234"})
+
+    assert "error" in response
+    assert response["error"]["code"] == -32602
+    assert response["error"]["message"] == "validation_error"
+
+
+def test_unknown_method_returns_method_not_found() -> None:
+    response = _request("desktop.unknown")
+
+    assert response["error"]["code"] == -32601


### PR DESCRIPTION
## Summary
- Add newline-delimited JSON-RPC server for desktop read methods
- Expose list_runs, daily summary, extracted symbols, symbol detail, debate transcript, and history search
- Add schema-focused tests for JSON responses, missing dates, validation errors, and read-only behavior

Closes #46

## Verification
- uv run pytest tests/test_desktop_rpc.py tests/test_desktop_read_model.py
- uv run ruff check src/quantmind/desktop tests/test_desktop_rpc.py tests/test_desktop_read_model.py
- uv run mypy src
- uv run pytest