### PR TITLE
feat: add desktop daily run service

### DIFF
--- a/src/quantmind/desktop/__init__.py
+++ b/src/quantmind/desktop/__init__.py
@@ -15,7 +15,15 @@ from quantmind.desktop.schemas import (
     ExtractedSymbol,
     PipelineRunSummary,
     PipelineStepView,
+    RunDailyHandle,
+    RunDailyOptions,
+    RunDailyStatus,
     SymbolDetail,
+)
+from quantmind.desktop.service import (
+    get_run_status,
+    start_daily_run,
+    wait_for_run,
 )
 
 __all__ = [
@@ -25,11 +33,17 @@ __all__ = [
     "ExtractedSymbol",
     "PipelineRunSummary",
     "PipelineStepView",
+    "RunDailyHandle",
+    "RunDailyOptions",
+    "RunDailyStatus",
     "SymbolDetail",
     "get_daily_summary",
     "get_debate_transcript",
+    "get_run_status",
     "get_symbol_detail",
     "list_extracted_symbols",
     "list_run_summaries",
     "search_history",
+    "start_daily_run",
+    "wait_for_run",
 ]

--- a/src/quantmind/desktop/rpc_server.py
+++ b/src/quantmind/desktop/rpc_server.py
@@ -17,6 +17,8 @@ from typing import Any
 from pydantic import BaseModel
 
 from quantmind.desktop import read_model
+from quantmind.desktop.schemas import RunDailyOptions
+from quantmind.desktop.service import DesktopServiceError, get_run_status, start_daily_run
 
 JsonDict = dict[str, Any]
 
@@ -102,6 +104,39 @@ def _desktop_search_history(params: JsonDict) -> Any:
     )
 
 
+def _get_bool(params: JsonDict, snake: str, camel: str, default: bool) -> bool:
+    value = params.get(snake, params.get(camel, default))
+    return bool(value)
+
+
+def _get_int(params: JsonDict, snake: str, camel: str, default: int) -> int:
+    value = params.get(snake, params.get(camel, default))
+    if value is None:
+        return default
+    return int(value)
+
+
+def _desktop_run_daily(params: JsonDict) -> Any:
+    options = RunDailyOptions(
+        date=_parse_date(params.get("date")),
+        force=_get_bool(params, "force", "force", False),
+        discover=_get_bool(params, "discover", "discover", True),
+        discover_limit=_get_int(params, "discover_limit", "discoverLimit", 50),
+        price_lookback_days=_get_int(params, "price_lookback_days", "priceLookbackDays", 45),
+        llm_debate=_get_bool(params, "llm_debate", "llmDebate", True),
+        pdf=_get_bool(params, "pdf", "pdf", False),
+        out_dir=str(params.get("out_dir", params.get("outDir", "reports"))),
+    )
+    return start_daily_run(options)
+
+
+def _desktop_get_run_status(params: JsonDict) -> Any:
+    run_id = params.get("run_id", params.get("runId"))
+    if not isinstance(run_id, str) or not run_id:
+        raise RpcError(-32602, "validation_error", {"field": "run_id", "detail": "required"})
+    return get_run_status(run_id)
+
+
 METHODS: dict[str, Callable[[JsonDict], Any]] = {
     "desktop.list_runs": _desktop_list_runs,
     "desktop.get_daily_summary": _desktop_get_daily_summary,
@@ -109,6 +144,8 @@ METHODS: dict[str, Callable[[JsonDict], Any]] = {
     "desktop.get_symbol_detail": _desktop_get_symbol_detail,
     "desktop.get_debate_transcript": _desktop_get_debate_transcript,
     "desktop.search_history": _desktop_search_history,
+    "desktop.run_daily": _desktop_run_daily,
+    "desktop.get_run_status": _desktop_get_run_status,
 }
 
 
@@ -142,6 +179,16 @@ def handle_jsonrpc(request: JsonDict) -> JsonDict | None:
         if e.data is not None:
             error["data"] = e.data
         return {"jsonrpc": "2.0", "id": request_id, "error": error}
+    except DesktopServiceError as e:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": -32000,
+                "message": e.kind,
+                "data": {"detail": e.detail},
+            },
+        }
     except Exception as e:
         return {
             "jsonrpc": "2.0",

--- a/src/quantmind/desktop/schemas.py
+++ b/src/quantmind/desktop/schemas.py
@@ -72,3 +72,32 @@ class DailySummary(BaseModel):
     extracted_count: int = 0
     debate_count: int = 0
     regime: dict[str, Any] | None = None
+
+
+class RunDailyOptions(BaseModel):
+    date: date
+    force: bool = False
+    discover: bool = True
+    discover_limit: int = 50
+    price_lookback_days: int = 45
+    llm_debate: bool = True
+    pdf: bool = False
+    out_dir: str = "reports"
+
+
+class RunDailyHandle(BaseModel):
+    run_id: str
+    date: date
+    status: PipelineStatus | str
+
+
+class RunDailyStatus(BaseModel):
+    run_id: str
+    date: date
+    status: PipelineStatus | str
+    detail: str = ""
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    steps: list[PipelineStepView] = Field(default_factory=list)
+    report_html: str | None = None
+    report_pdf: str | None = None

--- a/src/quantmind/desktop/service.py
+++ b/src/quantmind/desktop/service.py
@@ -1,0 +1,174 @@
+"""Operation service for desktop-triggered daily pipeline runs."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from quantmind.desktop.schemas import (
+    PipelineStepView,
+    RunDailyHandle,
+    RunDailyOptions,
+    RunDailyStatus,
+)
+from quantmind.pipeline import DailyPipelineResult
+
+
+@dataclass(frozen=True)
+class DesktopServiceError(Exception):
+    kind: str
+    detail: str
+
+
+@dataclass
+class _RunRecord:
+    run_id: str
+    options: RunDailyOptions
+    status: str = "running"
+    detail: str = ""
+    started_at: datetime = field(default_factory=datetime.now)
+    finished_at: datetime | None = None
+    steps: list[PipelineStepView] | None = None
+    report_html: str | None = None
+    report_pdf: str | None = None
+
+    def to_status(self) -> RunDailyStatus:
+        return RunDailyStatus(
+            run_id=self.run_id,
+            date=self.options.date,
+            status=self.status,
+            detail=self.detail,
+            started_at=self.started_at,
+            finished_at=self.finished_at,
+            steps=self.steps or [],
+            report_html=self.report_html,
+            report_pdf=self.report_pdf,
+        )
+
+
+def _ensure_llm_clis() -> None:
+    missing = [name for name in ("claude", "codex") if shutil.which(name) is None]
+    if missing:
+        raise DesktopServiceError(
+            "cli_missing",
+            "Required LLM CLI not found: " + ", ".join(missing),
+        )
+
+
+def _default_pipeline_context() -> Any:
+    from quantmind.cli import _default_pipeline_context as cli_default_pipeline_context
+
+    return cli_default_pipeline_context()
+
+
+def _execute_pipeline(options: RunDailyOptions) -> tuple[DailyPipelineResult, Any]:
+    from quantmind.pipeline import run_daily
+    from quantmind.report import generate_daily_report
+    from quantmind.storage import init_db
+
+    init_db()
+    if options.discover:
+        from quantmind.universe import bootstrap_market_data
+
+        bootstrap_market_data(
+            options.date,
+            limit=options.discover_limit,
+            lookback_days=options.price_lookback_days,
+        )
+    context = None
+    if options.llm_debate:
+        _ensure_llm_clis()
+        context = _default_pipeline_context()
+    pipe_result = run_daily(options.date, context=context, force=options.force)
+    paths = generate_daily_report(pipe_result, Path(options.out_dir), pdf=options.pdf)
+    return pipe_result, paths
+
+
+class DesktopRunManager:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._runs: dict[str, _RunRecord] = {}
+        self._active_run_id: str | None = None
+        self._threads: dict[str, threading.Thread] = {}
+
+    def start(self, options: RunDailyOptions) -> RunDailyHandle:
+        with self._lock:
+            if self._active_run_id is not None:
+                active = self._runs[self._active_run_id]
+                if active.status == "running":
+                    raise DesktopServiceError(
+                        "pipeline_running",
+                        f"Pipeline run {active.run_id} is already running",
+                    )
+            run_id = str(uuid.uuid4())
+            record = _RunRecord(run_id=run_id, options=options, started_at=datetime.now())
+            self._runs[run_id] = record
+            self._active_run_id = run_id
+            thread = threading.Thread(target=self._run, args=(run_id,), daemon=True)
+            self._threads[run_id] = thread
+            thread.start()
+        return RunDailyHandle(run_id=run_id, date=options.date, status="running")
+
+    def _run(self, run_id: str) -> None:
+        record = self._runs[run_id]
+        try:
+            pipe_result, paths = _execute_pipeline(record.options)
+            steps = [
+                PipelineStepView(
+                    name=step.name,
+                    status=step.status,
+                    detail=step.detail,
+                    started_at=step.started_at,
+                    finished_at=step.finished_at,
+                )
+                for step in pipe_result.steps
+            ]
+            failed = [step for step in steps if step.status == "failed"]
+            record.status = "failed" if failed else "success"
+            record.detail = "; ".join(step.detail for step in failed if step.detail)
+            record.steps = steps
+            record.report_html = str(paths.html)
+            record.report_pdf = str(paths.pdf) if paths.pdf else None
+        except DesktopServiceError as e:
+            record.status = "failed"
+            record.detail = f"{e.kind}: {e.detail}"
+        except Exception as e:
+            record.status = "failed"
+            record.detail = f"{type(e).__name__}: {e}"
+        finally:
+            record.finished_at = datetime.now()
+            with self._lock:
+                if self._active_run_id == run_id:
+                    self._active_run_id = None
+
+    def status(self, run_id: str) -> RunDailyStatus:
+        record = self._runs.get(run_id)
+        if record is None:
+            raise DesktopServiceError("missing_run", f"Unknown run id: {run_id}")
+        return record.to_status()
+
+    def wait(self, run_id: str, timeout: float | None = None) -> RunDailyStatus:
+        thread = self._threads.get(run_id)
+        if thread is not None:
+            thread.join(timeout)
+        return self.status(run_id)
+
+
+_RUN_MANAGER = DesktopRunManager()
+
+
+def start_daily_run(options: RunDailyOptions) -> RunDailyHandle:
+    return _RUN_MANAGER.start(options)
+
+
+def get_run_status(run_id: str) -> RunDailyStatus:
+    return _RUN_MANAGER.status(run_id)
+
+
+def wait_for_run(run_id: str, timeout: float | None = None) -> RunDailyStatus:
+    return _RUN_MANAGER.wait(run_id, timeout)

--- a/tests/test_desktop_rpc.py
+++ b/tests/test_desktop_rpc.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 import pytest
 
+from quantmind.desktop import service
 from quantmind.desktop.rpc_server import handle_jsonrpc
+from quantmind.pipeline import DailyPipelineResult, StepResult
 from quantmind.storage import get_conn, init_db
 
 
@@ -14,6 +16,7 @@ from quantmind.storage import get_conn, init_db
 def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
     init_db()
+    monkeypatch.setattr(service, "_RUN_MANAGER", service.DesktopRunManager())
 
 
 def _seed_rows() -> None:
@@ -99,3 +102,24 @@ def test_unknown_method_returns_method_not_found() -> None:
     response = _request("desktop.unknown")
 
     assert response["error"]["code"] == -32601
+
+
+def test_run_daily_rpc_starts_and_status_can_be_polled(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_execute(options: service.RunDailyOptions) -> tuple[DailyPipelineResult, object]:
+        result = DailyPipelineResult(as_of=options.date, regime=None)
+        result.steps.append(StepResult(name="regime", status="success"))
+        return result, type("Paths", (), {"html": Path("reports/day.html"), "pdf": None})()
+
+    monkeypatch.setattr(service, "_execute_pipeline", fake_execute)
+
+    started = _request(
+        "desktop.run_daily",
+        {"date": "2026-05-05", "discover": False, "llmDebate": False},
+    )
+    run_id = started["result"]["run_id"]
+    service.wait_for_run(run_id, timeout=1)
+    status = _request("desktop.get_run_status", {"runId": run_id})
+
+    assert started["result"]["status"] == "running"
+    assert status["result"]["status"] == "success"
+    assert status["result"]["steps"][0]["name"] == "regime"

--- a/tests/test_desktop_service.py
+++ b/tests/test_desktop_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import threading
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from quantmind.desktop import service
+from quantmind.desktop.schemas import RunDailyOptions
+from quantmind.pipeline import DailyPipelineResult, StepResult
+from quantmind.storage import init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+    monkeypatch.setattr(service, "_RUN_MANAGER", service.DesktopRunManager())
+
+
+def test_start_daily_run_completes_and_exposes_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_execute(options: RunDailyOptions) -> tuple[DailyPipelineResult, SimpleNamespace]:
+        result = DailyPipelineResult(as_of=options.date, regime=None)
+        result.steps.append(StepResult(name="screening", status="success", detail="ok"))
+        return result, SimpleNamespace(html=Path("reports/2026-05-05.html"), pdf=None)
+
+    monkeypatch.setattr(service, "_execute_pipeline", fake_execute)
+
+    handle = service.start_daily_run(
+        RunDailyOptions(date=date(2026, 5, 5), discover=False, llm_debate=False)
+    )
+    status = service.wait_for_run(handle.run_id, timeout=1)
+
+    assert handle.status == "running"
+    assert status.status == "success"
+    assert status.steps[0].name == "screening"
+    assert status.report_html == "reports/2026-05-05.html"
+
+
+def test_start_daily_run_prevents_concurrent_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    release = threading.Event()
+
+    def slow_execute(options: RunDailyOptions) -> tuple[DailyPipelineResult, SimpleNamespace]:
+        release.wait(timeout=2)
+        return DailyPipelineResult(as_of=options.date, regime=None), SimpleNamespace(html=Path("x"), pdf=None)
+
+    monkeypatch.setattr(service, "_execute_pipeline", slow_execute)
+    first = service.start_daily_run(
+        RunDailyOptions(date=date(2026, 5, 5), discover=False, llm_debate=False)
+    )
+
+    with pytest.raises(service.DesktopServiceError) as exc:
+        service.start_daily_run(
+            RunDailyOptions(date=date(2026, 5, 5), discover=False, llm_debate=False)
+        )
+
+    release.set()
+    service.wait_for_run(first.run_id, timeout=2)
+    assert exc.value.kind == "pipeline_running"
+
+
+def test_missing_llm_cli_is_reported_in_run_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service.shutil, "which", lambda _name: None)
+
+    handle = service.start_daily_run(
+        RunDailyOptions(date=date(2026, 5, 5), discover=False, llm_debate=True)
+    )
+    status = service.wait_for_run(handle.run_id, timeout=1)
+
+    assert status.status == "failed"
+    assert status.detail.startswith("cli_missing:")


### PR DESCRIPTION
## Summary
- Add guarded desktop run manager for starting one daily pipeline run at a time
- Expose run_daily and get_run_status over JSON-RPC with force/discover/llm/pdf options
- Report success, failed steps, missing Claude/Codex CLI errors, generated report paths, and polling status

Closes #47

## Verification
- uv run pytest tests/test_desktop_service.py tests/test_desktop_rpc.py
- uv run ruff check src/quantmind/desktop tests/test_desktop_service.py tests/test_desktop_rpc.py
- uv run mypy src
- uv run pytest