### PR TITLE
docs: make desktop app the primary operation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 #   DISCOVER=--no-discover  小型株候補・株価取得を無効化
 #   DISCOVER_LIMIT=50  取得する小型株候補数
 #   LLM_DEBATE=--no-llm-debate  Claude/Codex ディベートを無効化
+#   ELECTRON_RENDERER_URL  Electron dev window が読む renderer URL
 # --------------------------------------------------------------------------
 
 DATE     ?= $(shell date +%Y-%m-%d)
@@ -25,10 +26,12 @@ FORCE    ?=
 DISCOVER ?= --discover
 DISCOVER_LIMIT ?= 50
 LLM_DEBATE ?= --llm-debate
+ELECTRON_RENDERER_URL ?= http://127.0.0.1:5173
 
 UV_RUN := uv run
 
-.PHONY: help setup init-db info run run-pdf run-open backtest \
+.PHONY: help setup init-db desktop-setup desktop-dev desktop-window desktop-start desktop-test \
+        info run run-pdf run-open backtest \
         prices tdnet edinet edinet-download ir universe screen \
         position-list position-history position-summary \
         lint format test typecheck check pre-commit clean
@@ -38,13 +41,17 @@ help:
 	@echo ""
 	@echo "  セットアップ:"
 	@echo "    make setup          uv sync --all-extras"
+	@echo "    make desktop-setup  Electron app dependencies"
 	@echo "    make init-db        DuckDB スキーマ初期化"
 	@echo ""
 	@echo "  日常運用:"
 	@echo "    make info           バージョン確認"
-	@echo "    make run            小型株候補取得 + 日次パイプライン + Claude/Codex 議論 → HTML レポート (DATE=)"
-	@echo "    make run-pdf        日次パイプライン → HTML+PDF"
-	@echo "    make run-open       日次パイプライン → HTML を既定ブラウザで開く"
+	@echo "    make desktop-start  renderer build → Electron window"
+	@echo "    make desktop-dev    renderer dev server"
+	@echo "    make desktop-window dev server を Electron window で開く"
+	@echo "    make run            補助 HTML レポート出力 (DATE=)"
+	@echo "    make run-pdf        補助 HTML+PDF"
+	@echo "    make run-open       補助 HTML を既定ブラウザで開く"
 	@echo "    make backtest       ルールベース戦略のバックテスト (START=, END=)"
 	@echo ""
 	@echo "  データ収集:"
@@ -68,6 +75,21 @@ setup:
 
 init-db:
 	$(UV_RUN) python -m quantmind.storage init
+
+desktop-setup:
+	pnpm -C apps/desktop install
+
+desktop-dev:
+	pnpm -C apps/desktop dev
+
+desktop-window:
+	ELECTRON_RENDERER_URL=$(ELECTRON_RENDERER_URL) pnpm -C apps/desktop exec electron .
+
+desktop-start:
+	pnpm -C apps/desktop start
+
+desktop-test:
+	pnpm -C apps/desktop test
 
 # --- 日常運用 ---------------------------------------------------------------
 info:

--- a/README.md
+++ b/README.md
@@ -11,28 +11,44 @@
 
 - [docs/overview.md](docs/overview.md) — 概要（v1.0）
 - [docs/spec.md](docs/spec.md) — 詳細仕様草案（v0.1）
+- [docs/desktop-app.md](docs/desktop-app.md) — Electron デスクトップアプリ方針・起動手順
+- [docs/desktop-rpc-contract.md](docs/desktop-rpc-contract.md) — Electron IPC / Python JSON-RPC 契約
 
 ## セットアップ
 
 ```bash
 make setup          # uv sync --all-extras
+make desktop-setup  # apps/desktop の pnpm install
 make init-db        # DuckDB スキーマ初期化（~/.quantmind/quantmind.duckdb）
 ```
 
 データ保存先を変えたい場合は `export QUANTMIND_DATA_DIR=/path/to/dir` を `make init-db` の前に設定してください。
-`make run` は小型株候補と株価を取得し、ローカルの `claude` CLI と `codex` CLI を使って Bull/Bear ディベートを実行します。
+日次パイプラインの LLM 議論にはローカルの `claude` CLI と `codex` CLI を使います。未設定の場合は Electron 側の実行ステータスに `cli_missing` として返します。
 
 ## 日常運用
 
+通常の確認・実行は Electron の独立 window で行います。
+
 ```bash
 make info                                    # バージョン確認
-make run                                     # 小型株候補取得 + 日次パイプライン + Claude/Codex 議論 → reports/YYYY-MM-DD.html
+make desktop-start                           # renderer build → Electron window 起動
+make desktop-dev                             # renderer dev server 起動（開発用）
+make desktop-window                          # dev server を Electron window で開く（別 terminal）
+make desktop-test                            # desktop typecheck + build
+```
+
+Electron window では、日次サマリ、抽出銘柄、銘柄詳細、Bull/Bear/Judge 議論履歴、pipeline 実行履歴、日次パイプライン実行パネルを確認できます。
+
+HTML/PDF レポートは互換性維持とエクスポート用の補助出力です。
+
+```bash
+make run                                     # 日次パイプライン + 補助 HTML レポート
 make run DATE=2026-05-05                     # 指定日
 make run DATE=2026-05-05 FORCE=--force        # 成功済みステップも再実行
 make run DISCOVER=--no-discover               # 小型株候補・株価取得を無効化
 make run LLM_DEBATE=--no-llm-debate           # LLM 議論を無効化
-make run-open                                # 生成後にブラウザで開く
-make run-pdf                                 # PDF も生成（要 weasyprint）
+make run-open                                # 補助 HTML を既定ブラウザで開く
+make run-pdf                                 # 補助 PDF も生成（要 weasyprint）
 make backtest START=2024-01-01 END=2024-12-31
 
 # データ収集


### PR DESCRIPTION
## Summary
- Make README daily operation desktop-first with Electron setup/start/test commands
- Add Makefile targets for desktop setup, dev renderer, Electron dev window, start, and test
- Reframe HTML/PDF reports as auxiliary export outputs while preserving existing commands

Closes #49

## Verification
- make help
- uv run pytest tests/test_report.py
- pnpm -C apps/desktop test
- uv run pytest