### PR TITLE
test: add desktop E2E checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ELECTRON_RENDERER_URL ?= http://127.0.0.1:5173
 
 UV_RUN := uv run
 
-.PHONY: help setup init-db desktop-setup desktop-dev desktop-window desktop-start desktop-test \
+.PHONY: help setup init-db desktop-setup desktop-dev desktop-window desktop-start desktop-test desktop-demo-data \
         info run run-pdf run-open backtest \
         prices tdnet edinet edinet-download ir universe screen \
         position-list position-history position-summary \
@@ -49,6 +49,7 @@ help:
 	@echo "    make desktop-start  renderer build → Electron window"
 	@echo "    make desktop-dev    renderer dev server"
 	@echo "    make desktop-window dev server を Electron window で開く"
+	@echo "    make desktop-demo-data DATE=YYYY-MM-DD"
 	@echo "    make run            補助 HTML レポート出力 (DATE=)"
 	@echo "    make run-pdf        補助 HTML+PDF"
 	@echo "    make run-open       補助 HTML を既定ブラウザで開く"
@@ -90,6 +91,9 @@ desktop-start:
 
 desktop-test:
 	pnpm -C apps/desktop test
+
+desktop-demo-data:
+	$(UV_RUN) python -m quantmind.desktop.demo_data --date $(DATE)
 
 # --- 日常運用 ---------------------------------------------------------------
 info:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [docs/spec.md](docs/spec.md) — 詳細仕様草案（v0.1）
 - [docs/desktop-app.md](docs/desktop-app.md) — Electron デスクトップアプリ方針・起動手順
 - [docs/desktop-rpc-contract.md](docs/desktop-rpc-contract.md) — Electron IPC / Python JSON-RPC 契約
+- [docs/desktop-e2e.md](docs/desktop-e2e.md) — Desktop E2E / 運用確認チェックリスト
 
 ## セットアップ
 
@@ -35,6 +36,7 @@ make desktop-start                           # renderer build → Electron windo
 make desktop-dev                             # renderer dev server 起動（開発用）
 make desktop-window                          # dev server を Electron window で開く（別 terminal）
 make desktop-test                            # desktop typecheck + build
+make desktop-demo-data DATE=2026-05-05        # E2E 用のデモ履歴を投入
 ```
 
 Electron window では、日次サマリ、抽出銘柄、銘柄詳細、Bull/Bear/Judge 議論履歴、pipeline 実行履歴、日次パイプライン実行パネルを確認できます。

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: "./",
   plugins: [react()],
   server: {
     host: "127.0.0.1",

--- a/docs/desktop-e2e.md
+++ b/docs/desktop-e2e.md
@@ -1,0 +1,78 @@
+# Desktop E2E and Operations Checklist
+
+This checklist verifies the Electron desktop app, Python JSON-RPC service, existing CLI/report path, and missing-CLI behavior.
+
+## One-time Setup
+
+```bash
+make setup
+make desktop-setup
+make init-db
+```
+
+Use an isolated data directory for repeatable checks:
+
+```bash
+export QUANTMIND_DATA_DIR=/tmp/quantmind-desktop-e2e
+rm -rf "$QUANTMIND_DATA_DIR"
+make init-db
+make desktop-demo-data DATE=2026-05-05
+```
+
+## Automated Checks
+
+```bash
+uv run pytest
+pnpm -C apps/desktop test
+make help
+```
+
+Coverage expected from the automated suite:
+
+- read-only desktop RPC does not add `pipeline_runs`
+- missing dates and symbols return stable empty responses
+- guarded daily run API reports success and failed steps
+- concurrent desktop runs return `pipeline_running`
+- missing `claude` / `codex` binaries return `cli_missing`
+- existing HTML/PDF report tests still pass
+
+## Desktop UI Smoke
+
+```bash
+make desktop-start
+```
+
+In the Electron window:
+
+1. Set the date to `2026-05-05`.
+2. Confirm the summary shows `success`, `Extracted=1`, `Debates=1`, and `Regime=risk_on`.
+3. Confirm the extracted symbol table shows code `1234`, rank `1`, decision `buy`, and rules `volume_spike, tdnet_today`.
+4. Select `1234` and confirm the detail pane shows Bull, Bear, and Judge transcript entries.
+5. Confirm the pipeline run timeline contains `2026-05-05`.
+6. Toggle `LLM debate` on in an environment without `claude` or `codex`, run the panel, and confirm the run status reports `cli_missing`.
+
+## Development Window
+
+For renderer iteration:
+
+```bash
+make desktop-dev
+```
+
+In a second terminal:
+
+```bash
+make desktop-window
+```
+
+This still uses Electron as the UI host; Vite is only the renderer development server.
+
+## Existing Report Path
+
+HTML/PDF reports are auxiliary exports, not the primary UI:
+
+```bash
+make run DATE=2026-05-05 DISCOVER=--no-discover LLM_DEBATE=--no-llm-debate
+make run-pdf DATE=2026-05-05 DISCOVER=--no-discover LLM_DEBATE=--no-llm-debate
+make run-open DATE=2026-05-05 DISCOVER=--no-discover LLM_DEBATE=--no-llm-debate
+```

--- a/src/quantmind/desktop/demo_data.py
+++ b/src/quantmind/desktop/demo_data.py
@@ -1,0 +1,111 @@
+"""Seed deterministic demo data for desktop E2E checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date, datetime
+
+from quantmind.storage import get_conn, init_db
+
+
+def seed_demo_data(as_of: date) -> None:
+    """Insert one deterministic day of desktop-visible history."""
+    init_db()
+    judge = {
+        "recommendation": "buy",
+        "confidence": 0.82,
+        "summary": "出来高急増と当日開示が揃い、短期の検証対象として優先度が高い",
+        "key_reasons_for": ["volume_spike", "tdnet_today"],
+        "key_reasons_against": ["流動性低下リスク"],
+    }
+    with get_conn() as conn:
+        conn.execute("DELETE FROM llm_decisions WHERE id LIKE 'desktop-demo-%'")
+        conn.execute("DELETE FROM alerts WHERE id LIKE 'desktop-demo-%'")
+        conn.execute("DELETE FROM falsifiability_scenarios WHERE id LIKE 'desktop-demo-%'")
+        conn.execute("DELETE FROM pipeline_runs WHERE id LIKE 'desktop-demo-%'")
+        conn.execute("DELETE FROM screening_daily WHERE date=? AND code='1234'", [as_of])
+        conn.execute("DELETE FROM macro_regime_daily WHERE date=?", [as_of])
+
+        conn.execute(
+            "INSERT INTO macro_regime_daily(date, regime, score, components) VALUES (?, ?, ?, ?)",
+            [as_of, "risk_on", 0.71, json.dumps({"vix": 18.4, "n225_vs_ma25": 0.03})],
+        )
+        conn.execute(
+            "INSERT INTO screening_daily(date, code, score, rules_hit, rank) VALUES (?, ?, ?, ?, ?)",
+            [as_of, "1234", 4.6, json.dumps(["volume_spike", "tdnet_today"]), 1],
+        )
+        for idx, (step, status, detail) in enumerate(
+            [
+                ("regime", "success", "risk_on"),
+                ("universe", "success", "2 candidates"),
+                ("screening", "success", "1 extracted"),
+                ("debate", "success", "conversation desktop-demo-conversation"),
+            ],
+            start=1,
+        ):
+            conn.execute(
+                "INSERT INTO pipeline_runs(id, run_date, step, status, detail, started_at, finished_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    f"desktop-demo-run-{idx}",
+                    as_of,
+                    step,
+                    status,
+                    detail,
+                    datetime(as_of.year, as_of.month, as_of.day, 9, idx),
+                    datetime(as_of.year, as_of.month, as_of.day, 9, idx, 20),
+                ],
+            )
+        for idx, (role, output, confidence) in enumerate(
+            [
+                ("bull", "Bull: 小型株の出来高が急増し、当日開示も追い風。", None),
+                ("bear", "Bear: 流動性低下と材料一巡の反動には注意。", None),
+                ("judge", json.dumps(judge, ensure_ascii=False), 0.82),
+            ],
+            start=1,
+        ):
+            conn.execute(
+                "INSERT INTO llm_decisions("
+                "id, code, as_of_date, role, model, system_prompt, prompt, output, confidence, "
+                "conversation_id, duration_sec, created_at"
+                ") VALUES (?, '1234', ?, ?, 'demo', ?, ?, ?, ?, 'desktop-demo-conversation', ?, ?)",
+                [
+                    f"desktop-demo-llm-{idx}",
+                    as_of,
+                    role,
+                    f"{role} system prompt",
+                    f"{role} user prompt",
+                    output,
+                    confidence,
+                    0.1 * idx,
+                    datetime(as_of.year, as_of.month, as_of.day, 9, 10 + idx),
+                ],
+            )
+        conn.execute(
+            "INSERT INTO falsifiability_scenarios("
+            "id, code, narrative, quantitative_triggers, qualitative_triggers, status"
+            ") VALUES (?, '1234', ?, ?, ?, 'active')",
+            [
+                "desktop-demo-scenario",
+                "出来高が急減し、開示後の買いが続かない場合は仮説を棄却",
+                json.dumps(["volume_ratio_20d <= 0.5", "drawdown_pct <= -12"]),
+                json.dumps(["追加開示がない", "競合が類似施策を発表"]),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO alerts(id, code, scenario_id, trigger_kind, detail) "
+            "VALUES ('desktop-demo-alert', '1234', 'desktop-demo-scenario', 'quantitative', 'demo alert')",
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", default=date.today().isoformat())
+    args = parser.parse_args()
+    seed_demo_data(date.fromisoformat(args.date))
+    print(f"seeded desktop demo data for {args.date}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_desktop_e2e.py
+++ b/tests/test_desktop_e2e.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from quantmind.desktop.demo_data import seed_demo_data
+from quantmind.desktop.rpc_server import handle_jsonrpc
+from quantmind.storage import get_conn, init_db
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QUANTMIND_DATA_DIR", str(tmp_path))
+    init_db()
+
+
+def _rpc(method: str, params: dict[str, object]) -> dict[str, object]:
+    response = handle_jsonrpc({"jsonrpc": "2.0", "id": "e2e", "method": method, "params": params})
+    assert response is not None
+    assert "error" not in response
+    return response["result"]  # type: ignore[return-value]
+
+
+def test_desktop_history_e2e_flow_restores_symbols_and_debate_without_mutation() -> None:
+    seed_demo_data(date(2026, 5, 5))
+    with get_conn(read_only=True) as conn:
+        before = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
+
+    summary = _rpc("desktop.get_daily_summary", {"date": "2026-05-05"})
+    symbols = _rpc("desktop.list_extracted_symbols", {"date": "2026-05-05"})
+    detail = _rpc("desktop.get_symbol_detail", {"date": "2026-05-05", "code": "1234"})
+    runs = _rpc("desktop.list_runs", {"limit": 5})
+
+    with get_conn(read_only=True) as conn:
+        after = conn.execute("SELECT COUNT(*) FROM pipeline_runs").fetchone()[0]
+
+    assert before == after
+    assert summary["latest_status"] == "success"
+    assert summary["extracted_count"] == 1
+    assert symbols[0]["code"] == "1234"
+    assert symbols[0]["recommendation"] == "buy"
+    assert detail["debate"]["conversation_id"] == "desktop-demo-conversation"
+    assert [msg["role"] for msg in detail["debate"]["messages"]] == ["bull", "bear", "judge"]
+    assert runs[0]["date"] == "2026-05-05"


### PR DESCRIPTION
## Summary
- Add deterministic desktop demo data seeding and Makefile target for repeatable UI checks
- Add desktop E2E documentation covering setup, automated checks, UI smoke, missing CLI handling, and report export compatibility
- Add JSON-RPC E2E test proving seeded history, extracted symbols, debate transcript, pipeline runs, and read-only behavior
- Fix Vite production asset base so Electron file:// production builds render correctly

Closes #50

## Verification
- uv run pytest tests/test_desktop_e2e.py tests/test_desktop_rpc.py tests/test_desktop_service.py tests/test_report.py
- pnpm -C apps/desktop test
- make help
- uv run ruff check src tests
- uv run mypy src
- uv run pytest
- QUANTMIND_DATA_DIR=/private/tmp/quantmind-desktop-e2e uv run python -m quantmind.desktop.demo_data --date 2026-05-05
- QUANTMIND_DATA_DIR=/private/tmp/quantmind-desktop-e2e pnpm -C apps/desktop start
- Computer Use verified Electron window shows 2026-05-05 status=success, Extracted=1, Debates=1, Regime=risk_on, symbol 1234 buy, Bull/Bear/Judge transcript, scenarios=1, alerts=1